### PR TITLE
Types definitions for PHP 8.2

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -510,8 +510,13 @@
         'match': '''(?xi)
           (:)\\s*
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+            # nullable type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+            # union, intersection or DNF type
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            (?: \\s*[|&]\\s*
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            )+
           )
           (?=\\s*(?:{|/[/*]|\\#|$))
         '''
@@ -560,8 +565,13 @@
         'match': '''(?xi)
           (:)\\s*
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+            # nullable type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+            # union, intersection or DNF type
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            (?: \\s*[|&]\\s*
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            )+
           )
           (?=\\s*(?:=>|/[/*]|\\#|$))
         '''
@@ -601,7 +611,7 @@
     'contentName': 'meta.function.parameters.php'
     'end': '''(?xi)
       (\\)) \\s* ( : \\s*
-        (?:\\?\\s*)? (?!\\s) [a-z0-9_\\x{7f}-\\x{10ffff}\\\\\\s\\|&]+ (?<!\\s)
+        (?:\\?\\s*)? (?!\\s) [a-z0-9_\\x{7f}-\\x{10ffff}\\\\\\s\\|&()]+ (?<!\\s)
       )?
       (?=\\s*(?:{|/[/*]|\\#|$|;))
     '''
@@ -624,8 +634,13 @@
         'begin': '''(?xi)
           ((?:(?:public|private|protected|readonly)(?:\\s+|(?=\\?)))++)
           (?: (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+            # nullable type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+            # union, intersection or DNF type
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            (?: \\s*[|&]\\s*
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            )+
           ) \\s+ )?
           ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
         '''
@@ -704,8 +719,13 @@
     'contentName': 'meta.function.parameters.php'
     'end': '''(?xi)
       (\\)) (?: \\s* (:) \\s* (
-        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-        [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+        # nullable type
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+        # union, intersection or DNF type
+        (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+        (?: \\s*[|&]\\s*
+        (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+        )+
       ) )?
       (?=\\s*(?:{|/[/*]|\\#|$|;))
     '''
@@ -740,8 +760,13 @@
     'match': '''(?xi)
       ((?:(?:public|private|protected|static|readonly)(?:\\s+|(?=\\?)))++)                     # At least one modifier
       (
-        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-        [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+        # nullable type
+        (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+        # union, intersection or DNF type
+        (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+        (?: \\s*[|&]\\s*
+        (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+        )+
       )?
       \\s+ ((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)          # Variable name
     '''
@@ -1570,8 +1595,13 @@
         # Variadic
         'match': '''(?xi)
           (?: (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+            # nullable type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+            # union, intersection or DNF type
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            (?: \\s*[|&]\\s*
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            )+
           ) \\s+ )?
           ((?:(&)\\s*)?(\\.\\.\\.)(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
           (?=\\s*(?:,|\\)|/[/*]|\\#|$)) # A closing parentheses (end of argument list) or a comma or a comment
@@ -1597,8 +1627,13 @@
         # Typehinted
         'begin': '''(?xi)
           (
-            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |                                        # nullable type
-            [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ (?: \\s*[|&]\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ # union type
+            # nullable type
+            (?:\\?\\s*)? [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ |
+            # union, intersection or DNF type
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            (?: \\s*[|&]\\s*
+            (?: [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+ | \\(\\s* [a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+(?:\\s*&\\s*[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)+ \\s*\\) )
+            )+
           )
           \\s+ ((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
         '''
@@ -2507,14 +2542,21 @@
         'name': 'punctuation.separator.delimiter.php'
       }
       {
-        # false is allowed in unions
-        'match': '(?i)\\b(null|int|float|bool|string|array|object|callable|iterable|false|mixed|void)\\b',
+        'match': '(?i)\\b(null|int|float|bool|string|array|object|callable|iterable|true|false|mixed|void)\\b',
         'name': 'keyword.other.type.php'
       }
       {
         # static is only allowed in return of methods
         'match': '(?i)\\b(parent|self)\\b',
         'name': 'storage.type.php'
+      }
+      {
+        'match': '\\(',
+        'name': 'punctuation.definition.type.begin.bracket.round.php',
+      }
+      {
+        'match': '\\)',
+        'name': 'punctuation.definition.type.end.bracket.round.php',
       }
       {
         'include': '#class-name'
@@ -2691,6 +2733,14 @@
           {
             'match': '[|&]'
             'name': 'punctuation.separator.delimiter.php'
+          }
+          {
+            'match': '\\('
+            'name': 'punctuation.definition.type.begin.bracket.round.php'
+          }
+          {
+            'match': '\\)'
+            'name': 'punctuation.definition.type.end.bracket.round.php'
           }
         ]
   'php_doc_types_array_multiple':


### PR DESCRIPTION
Implemented RFCs:
https://wiki.php.net/rfc/null-false-standalone-types
https://wiki.php.net/rfc/true-type
https://wiki.php.net/rfc/dnf_types

Like before, there are 2 stages: one is detecting the general type hint structure, the second is extracting exact tokens. Multiline types are still not supported, which might be desired with introduction of more complex types.
First stage regex is identical in different parts of code:
- closure return
- arrow return
- constructor property promotion
- function/method return type
- typed properties
- typed vardic
- typed parameter