### PR TITLE
Readonly classes

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -284,13 +284,22 @@
   {
     'begin': '''(?ix)
         (?:
-          \\b(?:(abstract|final)\\s+)?(class)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
-          |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*\\b(class)\\b # anonymous class
+          \\b((?:(?:final|abstract|readonly)\\s+)*)(class)\\s+([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
+          |\\b(new)\\b\\s*(\\#\\[.*\\])?\\s*(?:(readonly)\\s+)?\\b(class)\\b # anonymous class
         )
       '''
     'beginCaptures':
       '1':
-        'name': 'storage.modifier.${1:/downcase}.php'
+        'patterns': [
+          {
+            'match': 'final|abstract'
+            'name': 'storage.modifier.${0:/downcase}.php'
+          }
+          {
+            'match': 'readonly'
+            'name': 'storage.modifier.php'
+          }
+        ]
       '2':
         'name': 'storage.type.class.php'
       '3':
@@ -304,6 +313,8 @@
           }
         ]
       '6':
+        'name': 'storage.modifier.php'
+      '7':
         'name': 'storage.type.class.php'
     'end': '}|(?=\\?>)'
     'endCaptures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -718,6 +718,24 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.php', 'meta.class.php']
       expect(tokens[4]).toEqual value: 'Test', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
 
+    it 'should tokenize readonly correctly', ->
+      {tokens} = grammar.tokenizeLine 'readonly class Foo {}'
+
+      expect(tokens[0]).toEqual value: 'readonly', scopes: ['source.php', 'meta.class.php', 'storage.modifier.php']
+      expect(tokens[2]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+
+      {tokens} = grammar.tokenizeLine 'readonly final class Foo {}'
+
+      expect(tokens[0]).toEqual value: 'readonly', scopes: ['source.php', 'meta.class.php', 'storage.modifier.php']
+      expect(tokens[2]).toEqual value: 'final', scopes: ['source.php', 'meta.class.php', 'storage.modifier.final.php']
+      expect(tokens[4]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+
+      {tokens} = grammar.tokenizeLine 'abstract readonly class Foo {}'
+
+      expect(tokens[0]).toEqual value: 'abstract', scopes: ['source.php', 'meta.class.php', 'storage.modifier.abstract.php']
+      expect(tokens[2]).toEqual value: 'readonly', scopes: ['source.php', 'meta.class.php', 'storage.modifier.php']
+      expect(tokens[4]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+
     it 'tokenizes classes declared immediately after another class ends', ->
       {tokens} = grammar.tokenizeLine 'class Test {}final class Test2 {}'
 
@@ -1183,6 +1201,22 @@ describe 'PHP grammar', ->
         expect(tokens[10]).toEqual value: ':', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.separator.colon.php']
         expect(tokens[12]).toEqual value: '123', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'constant.numeric.decimal.php']
         expect(tokens[13]).toEqual value: ')', scopes: ['source.php', 'meta.class.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
+
+      it 'should tokenize readonly anonymous class', ->
+        {tokens} = grammar.tokenizeLine 'new readonly class{}'
+
+        expect(tokens[0]).toEqual value: 'new', scopes: ['source.php', 'meta.class.php', 'keyword.other.new.php']
+        expect(tokens[2]).toEqual value: 'readonly', scopes: ['source.php', 'meta.class.php', 'storage.modifier.php']
+        expect(tokens[4]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
+
+        {tokens} = grammar.tokenizeLine 'new #[ExampleAttribute] readonly class{}'
+
+        expect(tokens[0]).toEqual value: 'new', scopes: ['source.php', 'meta.class.php', 'keyword.other.new.php']
+        expect(tokens[2]).toEqual value: '#[', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php']
+        expect(tokens[3]).toEqual value: 'ExampleAttribute', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php', 'support.attribute.php']
+        expect(tokens[4]).toEqual value: ']', scopes: ['source.php', 'meta.class.php', 'meta.attribute.php']
+        expect(tokens[6]).toEqual value: 'readonly', scopes: ['source.php', 'meta.class.php', 'storage.modifier.php']
+        expect(tokens[8]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
 
   describe 'enums', ->
     it 'should tokenize enums correctly', ->


### PR DESCRIPTION
Implemented RFCs:
https://wiki.php.net/rfc/readonly_classes

This PR implements readonly classes. Anonymous readonly classes were omitted by oversight in PHP 8.2, but are already [implemented for PHP 8.3](https://github.com/php/php-src/pull/10381), so I'm adding support for these already.

As side effect of this PR, nonsense pairings will be tokenized e.g. `abstact final readonly final`, before there were only 3 options `final`, `abstract` or none, now there is more, so to keep pattern simple any combination is tokenized. Such relaxed rules are already in use for method and property visibility.