### PR TITLE
New attributes in PHP 8.2

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1019,7 +1019,7 @@
       {
         # There will be other attributes in the future
         'match': '''(?xi)
-          (\\\\)?\\b(Attribute)\\b
+          (\\\\)?\\b(Attribute|SensitiveParameter|AllowDynamicProperties|ReturnTypeWillChange)\\b
         '''
         'name': 'support.attribute.builtin.php'
         'captures':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2639,6 +2639,21 @@ describe 'PHP grammar', ->
       expect(lines[1][0]).toEqual value: 'class', scopes: ['source.php', 'meta.class.php', 'storage.type.class.php']
       expect(lines[1][2]).toEqual value: 'FooAttribute', scopes: ['source.php', 'meta.class.php', 'entity.name.type.class.php']
 
+      lines = grammar.tokenizeLines '''
+        #[Attribute]
+        #[Attributes]
+        #[SensitiveParameter]
+        #[\\AllowDynamicProperties]
+        #[ReturnTypeWillChange]
+      '''
+
+      expect(lines[0][1]).toEqual value: 'Attribute', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php']
+      expect(lines[1][1]).toEqual value: 'Attributes', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.php']
+      expect(lines[2][1]).toEqual value: 'SensitiveParameter', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php']
+      expect(lines[3][1]).toEqual value: '\\', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php', 'punctuation.separator.inheritance.php']
+      expect(lines[3][2]).toEqual value: 'AllowDynamicProperties', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php']
+      expect(lines[4][1]).toEqual value: 'ReturnTypeWillChange', scopes: ['source.php', 'meta.attribute.php', 'support.attribute.builtin.php']
+
   describe 'PHPDoc', ->
     it 'should tokenize @api tag correctly', ->
       lines = grammar.tokenizeLines '''


### PR DESCRIPTION
Implemented RFCs:
https://wiki.php.net/rfc/redact_parameters_in_back_traces
https://wiki.php.net/rfc/deprecate_dynamic_properties
https://wiki.php.net/rfc/internal_method_return_types (Missed for PHP 8.1)