### PR TITLE
Fix phpdoc types

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2701,6 +2701,10 @@
           {
             'include': '#php_doc_types'
           }
+          {
+            'match': '[|&]'
+            'name': 'punctuation.separator.delimiter.php'
+          }
         ]
       }
       {
@@ -2723,7 +2727,7 @@
       }
     ]
   'php_doc_types':
-    'match': '(?i)\\??[a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*([|&]\\??[a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*)*'
+    'match': '(?i)\\??[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+([|&]\\??[a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)*'
     'captures':
       '0':
         'patterns': [
@@ -2745,14 +2749,6 @@
             'match': '[|&]'
             'name': 'punctuation.separator.delimiter.php'
           }
-          {
-            'match': '\\('
-            'name': 'punctuation.definition.type.begin.bracket.round.php'
-          }
-          {
-            'match': '\\)'
-            'name': 'punctuation.definition.type.end.bracket.round.php'
-          }
         ]
   'php_doc_types_array_multiple':
     # Multiple types array: (int|string|(int|string)[])[]
@@ -2760,7 +2756,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.type.begin.bracket.round.phpdoc.php'
-    'end': '(\\))(\\[\\])|(?=\\*/)'
+    'end': '(\\))(\\[\\])?|(?=\\*/)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.type.end.bracket.round.phpdoc.php'
@@ -2783,7 +2779,7 @@
     ]
   'php_doc_types_array_single':
     # Singular type array: int[]
-    'match': '(?i)([a-z_\\x{7f}-\\x{10ffff}\\\\][a-z0-9_\\x{7f}-\\x{10ffff}\\\\]*)(\\[\\])'
+    'match': '(?i)([a-z0-9_\\x{7f}-\\x{10ffff}\\\\]+)(\\[\\])'
     'captures':
       '1':
         'patterns': [

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3121,13 +3121,13 @@ describe 'PHP grammar', ->
         expect(lines[1][4]).toEqual value: 'Foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][5]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
         expect(lines[1][6]).toEqual value: 'Bar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
-        expect(lines[1][7]).toEqual value: ')', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php']
+        expect(lines[1][7]).toEqual value: ')', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.definition.type.end.bracket.round.phpdoc.php']
         expect(lines[1][8]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
         expect(lines[1][9]).toEqual value: 'false', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
-        expect(lines[1][11]).toEqual value: 'description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
+        expect(lines[1][10]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should end the PHPDoc at the ending comment even if there are malformed types', ->
-        {tokens} = grammar.tokenizeLine '/** @var array(string) */'
+        {tokens} = grammar.tokenizeLine '/** @var array(string */'
 
         expect(tokens[8]).toEqual value: '*/', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'punctuation.definition.comment.php']
 


### PR DESCRIPTION
Quick fix for phpdoc types, there is more changes needed to implement more complex types e.g. generics

Fixed problems:
- Consuming multiple lines
  <img width="394" alt="image" src="https://user-images.githubusercontent.com/1314456/196933858-705001fe-d46d-421c-8956-9295ad409685.png">
  <img width="394" alt="image" src="https://user-images.githubusercontent.com/5622673/238633996-0ffdb608-b2a9-4c7d-a07f-a3e18078e252.png">
- Namespace not highlighted
  <img width="394" alt="image" src="https://user-images.githubusercontent.com/54907080/189702624-e8910653-e6eb-4de1-a463-55bbe8aaf262.png">