### PR TITLE
Update PHPDoc to support spaces in array shapes

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2855,9 +2855,11 @@
     ]
   'php_doc_types_array_shape':
     # array shape: {key1: string, key2: int}
-    'begin': '\\{'
+    'begin': '(array)(\\{)'
     'beginCaptures':
-      '0':
+      '1':
+        'name': 'keyword.other.type.php'
+      '2':
         'name': 'punctuation.definition.type.begin.bracket.curly.phpdoc.php'
     'end': '(\\})'
     'endCaptures':
@@ -2886,9 +2888,11 @@
     ]
   'php_doc_types_array_with_key_type':
     # array with type key: array<string, int>
-    'begin': '\\<'
+    'begin': '(array)(\\<)'
     'beginCaptures':
-      '0':
+      '1':
+        'name': 'keyword.other.type.php'
+      '2':
         'name': 'punctuation.definition.type.begin.bracket.angle.phpdoc.php'
     'end': '(\\>)'
     'endCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2763,6 +2763,12 @@
             'include': '#php_doc_types_array_single'
           }
           {
+            "include": "#php_doc_types_array_with_key_type"
+          }
+          {
+            "include": "#php_doc_types_array_shape"
+          }
+          {
             'include': '#php_doc_types'
           }
           {
@@ -2834,10 +2840,78 @@
         'include': '#php_doc_types_array_single'
       }
       {
+        "include": "#php_doc_types_array_with_key_type"
+      }
+      {
+        "include": "#php_doc_types_array_shape"
+      }
+      {
         'include': '#php_doc_types'
       }
       {
         'match': '[|&]'
+        'name': 'punctuation.separator.delimiter.php'
+      }
+    ]
+  'php_doc_types_array_shape':
+    # array shape: {key1: string, key2: int}
+    'begin': '\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.type.begin.bracket.curly.phpdoc.php'
+    'end': '(\\})'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.type.end.bracket.curly.phpdoc.php'
+    'patterns': [
+      {
+        'include': '#php_doc_types_array_multiple'
+      }
+      {
+        'include': '#php_doc_types_array_single'
+      }
+      {
+        "include": "#php_doc_types_array_with_key_type"
+      }
+      {
+        "include": "#php_doc_types_array_shape"
+      }
+      {
+        'include': '#php_doc_types'
+      }
+      {
+        'match': '[,]\\s*'
+        'name': 'punctuation.separator.delimiter.php'
+      }
+    ]
+  'php_doc_types_array_with_key_type':
+    # array with type key: array<string, int>
+    'begin': '\\<'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.type.begin.bracket.angle.phpdoc.php'
+    'end': '(\\>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.type.end.bracket.angle.phpdoc.php'
+    'patterns': [
+      {
+        'include': '#php_doc_types_array_multiple'
+      }
+      {
+        'include': '#php_doc_types_array_single'
+      }
+      {
+        "include": "#php_doc_types_array_with_key_type"
+      }
+      {
+        "include": "#php_doc_types_array_shape"
+      }
+      {
+        'include': '#php_doc_types'
+      }
+      {
+        'match': '[,]\\s*'
         'name': 'punctuation.separator.delimiter.php'
       }
     ]


### PR DESCRIPTION
### Description of the Change

In VS Code, when viewing PHPDoc with spaces, the tokenization does not allow spaces. An example is below.

```php
/**
 * PHPDoc
 *
 * @param int $var1 Variable 1
 * @param string $var2 Variable 2
 * @param string|null $var3 Variable 3
 * @param (string|null)[] $var4 Variable 4
 * @param array<string|null,int> $var5 Variable 5
 * @param array<string|null, int> $var6 Variable 6
 * @param array{key1:string|null,key2:int} $var7 Variable 7
 * @param array{key1: string|null, key2: int} $var8 Variable 8
 * @param array{
 * 	key1: string|null,
 *  key2: int
 * } $var9 Variable 9
 * @param array{key1: string|null, key2: array<string, int>} $var10 Variable 10
 * @param MyClass $var11 Variable 11
 * @param \MyNameSpace\MyClass $var12 Variable 12
 * @param \MyNameSpace\MyClass|MyOtherClass $var13 Variable 13
 * @param \MyNameSpace\MyClass&\MyNamespace\MyOtherClass $var14 Variable 14
 *
 * @return array{
 * 	key1: string,
 * 	key2: int|null,
 * 	key3: array<int, string>
 *  key4: array{
 * 		subkey1: array {
 * 			subsubkey: string|null
 * 		}
 * 	}
 * } Return value
 */
```

## Current VS Code
<img width="580" height="583" alt="image" src="https://github.com/user-attachments/assets/df374a22-b888-4475-a778-63f319b66500" />

## With this PR
<img width="585" height="580" alt="image" src="https://github.com/user-attachments/assets/a0ab2e2e-41ec-44d0-9332-460e842662e3" />


### Alternate Designs

I didn't consider other alternatives. This seemed the most straightforward.

### Possible Drawbacks

It could break tokenization of the remainder of the file if there is an opening `array{` and `array<` with no closing bracket, but that's probably a good think since you'll know that the PHPDoc is incorrect.