### PR TITLE
feat: Tokenize variable/parameter names in PHPDoc

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2763,13 +2763,27 @@
           '1':
             'name': 'keyword.other.phpdoc.php'
           '2':
-            'name': 'meta.function.parameters.php meta.function.parameter.variadic.php variable.other.php'
-          '3':
-            'name': 'storage.modifier.reference.php'
-          '4':
-            'name': 'keyword.operator.variadic.php'
-          '5':
-            'name': 'punctuation.definition.variable.php'
+            'name': 'meta.function.parameters.php'
+            'patterns': [
+              {
+                'match': '''(?x)
+                  (?:(&)\\s*)?
+                  (\\.\\.\\.)
+                  (\\$)
+                  [A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*
+                '''
+                'name': 'meta.function.parameter.variadic.php'
+                'captures':
+                  '0':
+                    'name': 'variable.other.php'
+                  '1':
+                    'name': 'storage.modifier.reference.php'
+                  '2':
+                    'name': 'keyword.operator.variadic.php'
+                  '3':
+                    'name': 'punctuation.definition.variable.php'
+              }
+            ]
       }
       {
         # @param tag followed directly by a parameter name without a type expression.
@@ -2784,11 +2798,23 @@
           '1':
             'name': 'keyword.other.phpdoc.php'
           '2':
-            'name': 'meta.function.parameters.php variable.other.php'
-          '3':
-            'name': 'storage.modifier.reference.php'
-          '4':
-            'name': 'punctuation.definition.variable.php'
+            'name': 'meta.function.parameters.php'
+            'patterns': [
+              {
+                'match': '''(?x)
+                  (?:(&)\\s*)?
+                  (\\$)
+                  [A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*
+                '''
+                'captures':
+                  '0':
+                    'name': 'variable.other.php'
+                  '1':
+                    'name': 'storage.modifier.reference.php'
+                  '2':
+                    'name': 'punctuation.definition.variable.php'
+              }
+            ]
       }
       {
         # @param tag followed by a type expression and optional parameter name.
@@ -2819,19 +2845,46 @@
         '''
         'endCaptures':
           '1':
-            'name': 'meta.function.parameters.php meta.function.parameter.variadic.php variable.other.php'
-          '2':
-            'name': 'storage.modifier.reference.php'
-          '3':
-            'name': 'keyword.operator.variadic.php'
-          '4':
-            'name': 'punctuation.definition.variable.php'
+            'name': 'meta.function.parameters.php'
+            'patterns': [
+              {
+                'match': '''(?x)
+                  (?:(&)\\s*)?
+                  (\\.\\.\\.)
+                  (\\$)
+                  [A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*
+                '''
+                'name': 'meta.function.parameter.variadic.php'
+                'captures':
+                  '0':
+                    'name': 'variable.other.php'
+                  '1':
+                    'name': 'storage.modifier.reference.php'
+                  '2':
+                    'name': 'keyword.operator.variadic.php'
+                  '3':
+                    'name': 'punctuation.definition.variable.php'
+              }
+            ]
           '5':
-            'name': 'meta.function.parameters.php meta.function.parameter.typehinted.php variable.other.php'
-          '6':
-            'name': 'storage.modifier.reference.php'
-          '7':
-            'name': 'punctuation.definition.variable.php'
+            'name': 'meta.function.parameters.php'
+            'patterns': [
+              {
+                'match': '''(?x)
+                  (?:(&)\\s*)?
+                  (\\$)
+                  [A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*
+                '''
+                'name': 'meta.function.parameter.typehinted.php'
+                'captures':
+                  '0':
+                    'name': 'variable.other.php'
+                  '1':
+                    'name': 'storage.modifier.reference.php'
+                  '2':
+                    'name': 'punctuation.definition.variable.php'
+              }
+            ]
         'contentName': 'meta.other.type.phpdoc.php'
         'patterns': [
           {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2751,19 +2751,59 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
+        # @param tag followed directly by a variadic parameter name without a type expression.
+        # -  @param ...$parameter
+        # -  @param &...$parameter
+        'captures':
+          '1':
+            'name': 'keyword.other.phpdoc.php'
+          '2':
+            'name': 'meta.function.parameters.php meta.function.parameter.variadic.php variable.other.php'
+          '3':
+            'name': 'storage.modifier.reference.php'
+          '4':
+            'name': 'keyword.operator.variadic.php'
+          '5':
+            'name': 'punctuation.definition.variable.php'
+        'match': '(@param)\\s+((?:(&)\\s*)?(\\.\\.\\.)\\s*(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
+      }
+      {
+        # @param tag followed directly by a parameter name without a type expression.
+        # -  @param $parameter
+        # -  @param &$parameter
+        'captures':
+          '1':
+            'name': 'keyword.other.phpdoc.php'
+          '2':
+            'name': 'meta.function.parameters.php variable.other.php'
+          '3':
+            'name': 'storage.modifier.reference.php'
+          '4':
+            'name': 'punctuation.definition.variable.php'
+        'match': '(@param)\\s+((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
+      }
+      {
         # @param tag followed by a type expression and optional parameter name.
         # -  @param type $parameter
         'begin': '(@param)\\s+(?=[?A-Za-z0-9_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")'
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'
-        'end': '(?ix)(?:\\s+((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))?(?=\\s|\\*/)'
+        'end': '(?ix)(?:\\s+(?:((?:(&)\\s*)?(\\.\\.\\.)\\s*(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)|((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)))?(?=\\s|\\*/)'
         'endCaptures':
           '1':
-            'name': 'meta.function.parameters.php meta.function.parameter.typehinted.php variable.other.php'
+            'name': 'meta.function.parameters.php meta.function.parameter.variadic.php variable.other.php'
           '2':
             'name': 'storage.modifier.reference.php'
           '3':
+            'name': 'keyword.operator.variadic.php'
+          '4':
+            'name': 'punctuation.definition.variable.php'
+          '5':
+            'name': 'meta.function.parameters.php meta.function.parameter.typehinted.php variable.other.php'
+          '6':
+            'name': 'storage.modifier.reference.php'
+          '7':
             'name': 'punctuation.definition.variable.php'
         'contentName': 'meta.other.type.phpdoc.php'
         'patterns': [
@@ -2781,6 +2821,18 @@
             'name': 'punctuation.separator.delimiter.php'
           }
         ]
+      }
+      {
+        # @var tag followed directly by a variable name without a type expression.
+        # -  @var $variable
+        'captures':
+          '1':
+            'name': 'keyword.other.phpdoc.php'
+          '2':
+            'name': 'variable.other.php'
+          '3':
+            'name': 'punctuation.definition.variable.php'
+        'match': '(@var)\\s+((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
       }
       {
         # Tags followed by a type expression and optional variable name.

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2751,9 +2751,71 @@
         'match': '(@xlink)\\s+(.+)\\s*$'
       }
       {
-        # Tags followed by a type expression
+        # @param tag followed by a type expression and optional parameter name.
+        # -  @param type $parameter
+        'begin': '(@param)\\s+(?=[?A-Za-z0-9_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.other.phpdoc.php'
+        'end': '(?ix)(?:\\s+((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))?(?=\\s|\\*/)'
+        'endCaptures':
+          '1':
+            'name': 'meta.function.parameters.php meta.function.parameter.typehinted.php variable.other.php'
+          '2':
+            'name': 'storage.modifier.reference.php'
+          '3':
+            'name': 'punctuation.definition.variable.php'
+        'contentName': 'meta.other.type.phpdoc.php'
+        'patterns': [
+          {
+            'include': '#php_doc_types_array_multiple'
+          }
+          {
+            'include': '#php_doc_types_array_single'
+          }
+          {
+            'include': '#php_doc_types'
+          }
+          {
+            'match': '[|&]'
+            'name': 'punctuation.separator.delimiter.php'
+          }
+        ]
+      }
+      {
+        # Tags followed by a type expression and optional variable name.
+        # -  @<tag> type $variable
+        'begin': '(@(?:global|property(-(read|write))?|var))\\s+(?=[?A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.other.phpdoc.php'
+        'end': '(?ix)(?:\\s+((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))?(?=\\s|\\*/)'
+        'endCaptures':
+          '1':
+            'name': 'variable.other.php'
+          '2':
+            'name': 'punctuation.definition.variable.php'
+        'contentName': 'meta.other.type.phpdoc.php'
+        'patterns': [
+          {
+            'include': '#php_doc_types_array_multiple'
+          }
+          {
+            'include': '#php_doc_types_array_single'
+          }
+          {
+            'include': '#php_doc_types'
+          }
+          {
+            'match': '[|&]'
+            'name': 'punctuation.separator.delimiter.php'
+          }
+        ]
+      }
+      {
+        # Tags followed by a type expression.
         # -  @<tag> type
-        'begin': '(@(?:global|param|property(-(read|write))?|return|throws|var))\\s+(?=[?A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\()'
+        'begin': '(@(?:return|throws))\\s+(?=[?A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")'
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2754,6 +2754,11 @@
         # @param tag followed directly by a variadic parameter name without a type expression.
         # -  @param ...$parameter
         # -  @param &...$parameter
+        'match': '''(?x)
+          (@param)\\s+
+          ((?:(&)\\s*)?(\\.\\.\\.)(\\$)[A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
+          (?=\\s|\\*/)
+        '''
         'captures':
           '1':
             'name': 'keyword.other.phpdoc.php'
@@ -2765,12 +2770,16 @@
             'name': 'keyword.operator.variadic.php'
           '5':
             'name': 'punctuation.definition.variable.php'
-        'match': '(@param)\\s+((?:(&)\\s*)?(\\.\\.\\.)\\s*(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
       }
       {
         # @param tag followed directly by a parameter name without a type expression.
         # -  @param $parameter
         # -  @param &$parameter
+        'match': '''(?x)
+          (@param)\\s+
+          ((?:(&)\\s*)?(\\$)[A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*) # Variable name with possible reference
+          (?=\\s|\\*/)
+        '''
         'captures':
           '1':
             'name': 'keyword.other.phpdoc.php'
@@ -2780,7 +2789,6 @@
             'name': 'storage.modifier.reference.php'
           '4':
             'name': 'punctuation.definition.variable.php'
-        'match': '(@param)\\s+((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
       }
       {
         # @param tag followed by a type expression and optional parameter name.
@@ -2789,7 +2797,26 @@
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'
-        'end': '(?ix)(?:\\s+(?:((?:(&)\\s*)?(\\.\\.\\.)\\s*(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)|((?:(&)\\s*)?(\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)))?(?=\\s|\\*/)'
+        'end': '''(?ix)
+          (?:\\s+
+            (?:
+              # variadic parameter
+              (
+                (?:(&)\\s*)?          # reference operator
+                (\\.\\.\\.)           # variadic operator
+                (\\$)                 # variable sigil
+                [a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*
+              )|
+              # non-variadic parameter
+              (
+                (?:(&)\\s*)?          # reference operator
+                (\\$)                 # variable sigil
+                [a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*
+              )
+            )
+          )?
+          (?=\\s|\\*/)
+        '''
         'endCaptures':
           '1':
             'name': 'meta.function.parameters.php meta.function.parameter.variadic.php variable.other.php'
@@ -2823,8 +2850,13 @@
         ]
       }
       {
-        # @var tag followed directly by a variable name without a type expression.
-        # -  @var $variable
+        # Tags followed directly by a variable name without a type expression.
+        # -  @<tag> $variable
+        'match': '''(?x)
+          (@(?:global|property(?:-(?:read|write))?|var))\\s+
+          ((\\$)[A-Za-z_\\x{7f}-\\x{10ffff}][A-Za-z0-9_\\x{7f}-\\x{10ffff}]*)
+          (?=\\s|\\*/)
+        '''
         'captures':
           '1':
             'name': 'keyword.other.phpdoc.php'
@@ -2832,16 +2864,22 @@
             'name': 'variable.other.php'
           '3':
             'name': 'punctuation.definition.variable.php'
-        'match': '(@var)\\s+((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)(?=\\s|\\*/)'
       }
       {
         # Tags followed by a type expression and optional variable name.
         # -  @<tag> type $variable
-        'begin': '(@(?:global|property(-(read|write))?|var))\\s+(?=[?A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")'
+        'begin': '''(?x)
+          (@(?:global|property(-(read|write))?|var))\\s+(?=[?A-Za-z_\\x{7f}-\\x{10ffff}\\\\]|\\(|\\x27|")
+        '''
         'beginCaptures':
           '1':
             'name': 'keyword.other.phpdoc.php'
-        'end': '(?ix)(?:\\s+((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))?(?=\\s|\\*/)'
+        'end': '''(?ix)
+          (?:\\s+
+            ((\\$)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)
+          )?
+          (?=\\s|\\*/)
+        '''
         'endCaptures':
           '1':
             'name': 'variable.other.php'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3155,101 +3155,101 @@ describe 'PHP grammar', ->
         expect(lines[1][4]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should tokenize a typed @param variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param bool $foo */'
+        {tokens} = grammar.tokenizeLine '/** @param bool $fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[3]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
         expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variable name with description on an inline phpdoc', ->
-        {tokens} = grammar.tokenizeLine '/** @param bool $foo description */'
+        {tokens} = grammar.tokenizeLine '/** @param bool $fooBar description */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
         expect(tokens[8]).toEqual value: ' description ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should tokenize a typed @param by-reference variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param int &$foo */'
+        {tokens} = grammar.tokenizeLine '/** @param int &$fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'storage.modifier.reference.php']
         expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[8]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variadic variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param int ...$foo */'
+        {tokens} = grammar.tokenizeLine '/** @param int ...$fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
         expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+        expect(tokens[8]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
 
       it 'should tokenize a typed @param by-reference variadic variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param int &...$foo */'
+        {tokens} = grammar.tokenizeLine '/** @param int &...$fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'storage.modifier.reference.php']
         expect(tokens[7]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
         expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[9]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+        expect(tokens[9]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
 
       it 'should tokenize an untyped @param variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param $foo */'
+        {tokens} = grammar.tokenizeLine '/** @param $fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[5]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
 
       it 'should tokenize an untyped @param by-reference variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param &$foo */'
+        {tokens} = grammar.tokenizeLine '/** @param &$fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'storage.modifier.reference.php']
         expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
+        expect(tokens[6]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
 
       it 'should tokenize an untyped @param by-reference variadic variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param &...$foo description */'
+        {tokens} = grammar.tokenizeLine '/** @param &...$fooBar description */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'storage.modifier.reference.php']
         expect(tokens[5]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
         expect(tokens[8]).toEqual value: ' description ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should tokenize an untyped @param variadic variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @param ...$foo */'
+        {tokens} = grammar.tokenizeLine '/** @param ...$fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
         expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+        expect(tokens[6]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variable name at end-of-line in multiline phpdoc', ->
         lines = grammar.tokenizeLines '''
           /**
-          *@param bool $foo
+          *@param bool $fooBar
           */
         '''
 
         expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(lines[1][3]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(lines[1][5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(lines[1][6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][6]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variable name after union types', ->
         lines = grammar.tokenizeLines '''
           /**
-          *@param int|Class $foo description
+          *@param int|Class $fooBar description
           */
         '''
 
@@ -3258,67 +3258,111 @@ describe 'PHP grammar', ->
         expect(lines[1][4]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
         expect(lines[1][5]).toEqual value: 'Class', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(lines[1][8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][8]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
         expect(lines[1][9]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
-      it 'should tokenize a typed @param variable name with uppercase characters', ->
-        {tokens} = grammar.tokenizeLine '/** @param bool $fooBar */'
-
-        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
-        expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
-        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
-
       it 'should tokenize a typed @param variable name after quoted literal union types', ->
-        {tokens} = grammar.tokenizeLine '/** @param \'foo\'|\'bar\' $foo */'
+        {tokens} = grammar.tokenizeLine '/** @param \'foo\'|\'bar\' $fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[12]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[13]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[13]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variable name after a numeric-leading mixed literal union type', ->
-        {tokens} = grammar.tokenizeLine '/** @param 123|\'a\' $foo */'
+        {tokens} = grammar.tokenizeLine '/** @param 123|\'a\' $fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[10]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[11]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[11]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @param variable name after a numeric-leading numeric union type', ->
-        {tokens} = grammar.tokenizeLine '/** @param 123|345 $foo */'
+        {tokens} = grammar.tokenizeLine '/** @param 123|345 $fooBar */'
 
         expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[9]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[9]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
       it 'should tokenize a typed @var variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @var int $foo */'
+        {tokens} = grammar.tokenizeLine '/** @var int $fooBar */'
 
         expect(tokens[2]).toEqual value: '@var', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
 
-      it 'should tokenize an untyped @var variable name', ->
-        {tokens} = grammar.tokenizeLine '/** @var $foo */'
-
-        expect(tokens[2]).toEqual value: '@var', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
-        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[5]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
-
-      it 'should tokenize a typed @property variable name without function-parameter meta scopes', ->
-        {tokens} = grammar.tokenizeLine '/** @property int $foo */'
+      it 'should tokenize a typed @property variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property int $fooBar */'
 
         expect(tokens[2]).toEqual value: '@property', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
-        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize a typed @property-read variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property-read int $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@property-read', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize a typed @property-write variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property-write int $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@property-write', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize a typed @global variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @global int $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@global', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @var variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @var $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@var', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @property variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@property', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @property-read variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property-read $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@property-read', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @property-write variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @property-write $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@property-write', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @global variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @global $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@global', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
 
       it 'should not tokenize @return variable-like description text as a declared variable', ->
-        {tokens} = grammar.tokenizeLine '/** @return int $foo */'
+        {tokens} = grammar.tokenizeLine '/** @return int $fooBar */'
 
         expect(tokens[2]).toEqual value: '@return', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
-        expect(tokens[5]).toEqual value: ' $foo ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[5]).toEqual value: ' $fooBar ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
       it 'should tokenize a single nullable type', ->
         lines = grammar.tokenizeLines '''

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3154,6 +3154,113 @@ describe 'PHP grammar', ->
         expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
         expect(lines[1][4]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
 
+      it 'should tokenize a typed @param variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param bool $foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[3]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[5]).toEqual value: ' ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name with description on an inline phpdoc', ->
+        {tokens} = grammar.tokenizeLine '/** @param bool $foo description */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(tokens[8]).toEqual value: ' description ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
+      it 'should tokenize a typed @param by-reference variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param int &$foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'storage.modifier.reference.php']
+        expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name at end-of-line in multiline phpdoc', ->
+        lines = grammar.tokenizeLines '''
+          /**
+          *@param bool $foo
+          */
+        '''
+
+        expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(lines[1][3]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(lines[1][5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name after union types', ->
+        lines = grammar.tokenizeLines '''
+          /**
+          *@param int|Class $foo description
+          */
+        '''
+
+        expect(lines[1][1]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(lines[1][3]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(lines[1][4]).toEqual value: '|', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'punctuation.separator.delimiter.php']
+        expect(lines[1][5]).toEqual value: 'Class', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'support.class.php']
+        expect(lines[1][7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(lines[1][8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+        expect(lines[1][9]).toEqual value: ' description', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
+      it 'should tokenize a typed @param variable name with uppercase characters', ->
+        {tokens} = grammar.tokenizeLine '/** @param bool $fooBar */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'bool', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'fooBar', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name after quoted literal union types', ->
+        {tokens} = grammar.tokenizeLine '/** @param \'foo\'|\'bar\' $foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[12]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[13]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name after a numeric-leading mixed literal union type', ->
+        {tokens} = grammar.tokenizeLine '/** @param 123|\'a\' $foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[10]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[11]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param variable name after a numeric-leading numeric union type', ->
+        {tokens} = grammar.tokenizeLine '/** @param 123|345 $foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[9]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
+
+      it 'should tokenize a typed @var variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @var int $foo */'
+
+        expect(tokens[2]).toEqual value: '@var', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize a typed @property variable name without function-parameter meta scopes', ->
+        {tokens} = grammar.tokenizeLine '/** @property int $foo */'
+
+        expect(tokens[2]).toEqual value: '@property', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should not tokenize @return variable-like description text as a declared variable', ->
+        {tokens} = grammar.tokenizeLine '/** @return int $foo */'
+
+        expect(tokens[2]).toEqual value: '@return', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[5]).toEqual value: ' $foo ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
       it 'should tokenize a single nullable type', ->
         lines = grammar.tokenizeLines '''
           /**

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3182,6 +3182,58 @@ describe 'PHP grammar', ->
         expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php', 'punctuation.definition.variable.php']
         expect(tokens[8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.typehinted.php', 'variable.other.php']
 
+      it 'should tokenize a typed @param variadic variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param int ...$foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+        expect(tokens[7]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[8]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+
+      it 'should tokenize a typed @param by-reference variadic variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param int &...$foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
+        expect(tokens[6]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'storage.modifier.reference.php']
+        expect(tokens[7]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+        expect(tokens[8]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[9]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @param variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param $foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @param by-reference variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param &$foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'storage.modifier.reference.php']
+        expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @param by-reference variadic variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param &...$foo description */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '&', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'storage.modifier.reference.php']
+        expect(tokens[5]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+        expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+        expect(tokens[8]).toEqual value: ' description ', scopes: ['source.php', 'comment.block.documentation.phpdoc.php']
+
+      it 'should tokenize an untyped @param variadic variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @param ...$foo */'
+
+        expect(tokens[2]).toEqual value: '@param', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '...', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'keyword.operator.variadic.php']
+        expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[6]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.function.parameters.php', 'meta.function.parameter.variadic.php', 'variable.other.php']
+
       it 'should tokenize a typed @param variable name at end-of-line in multiline phpdoc', ->
         lines = grammar.tokenizeLines '''
           /**
@@ -3245,6 +3297,13 @@ describe 'PHP grammar', ->
         expect(tokens[4]).toEqual value: 'int', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'meta.other.type.phpdoc.php', 'keyword.other.type.php']
         expect(tokens[6]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
         expect(tokens[7]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
+
+      it 'should tokenize an untyped @var variable name', ->
+        {tokens} = grammar.tokenizeLine '/** @var $foo */'
+
+        expect(tokens[2]).toEqual value: '@var', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'keyword.other.phpdoc.php']
+        expect(tokens[4]).toEqual value: '$', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php', 'punctuation.definition.variable.php']
+        expect(tokens[5]).toEqual value: 'foo', scopes: ['source.php', 'comment.block.documentation.phpdoc.php', 'variable.other.php']
 
       it 'should tokenize a typed @property variable name without function-parameter meta scopes', ->
         {tokens} = grammar.tokenizeLine '/** @property int $foo */'


### PR DESCRIPTION
### Description of the Change

This PR improves PHPDoc tokenization by recognizing optional variable names after typed tags, including:

* `@param type $name`
* `@param type &$name` (by-reference)
* `@var type $name`
* `@global`, `@property`, `@property-read`, `@property-write` with typed variable names

It avoids false positives for `@return` / `@throws`, where variable-like text (e.g. `$foo`) in the description should not be tokenized as a declared variable.

Example syntax highlight in VSCode:

**Before:**

<img width="1148" height="785" alt="image" src="https://github.com/user-attachments/assets/6ff33149-50be-4ce6-87e7-d6e97159c110" />

**After:**

<img width="1139" height="786" alt="image" src="https://github.com/user-attachments/assets/d32c2b4e-05e2-44c8-b9b9-1010785785b5" />

### Sideffects

As a side effect (but rather positive one), this also adds missing tokenization for some PHPDoc union/literal type expressions. This is **not** full union-type support yet (I hope to address that in a future PR), but it makes the existing partial union highlighting behavior more consistent.

Example highlight in VSCode to illustrate what that means:

Before:
<img width="384" height="251" alt="image" src="https://github.com/user-attachments/assets/40dc5b8b-3d75-4bc0-a86a-2ac6ee406ec9" />

After:
<img width="381" height="250" alt="image" src="https://github.com/user-attachments/assets/194a77b1-cf43-4028-a406-739e05755d1e" />

---

The new scopes were chosen intentionally to reuse existing PHP/TextMate scope conventions, so current grammars and themes can highlight them correctly without changing theme; for example, `@param int $foo` now scopes `$foo` as a PHP function parameter (`variable.other.php` + `meta.function.parameter.typehinted.php` inside PHPDoc scope), while `@property string $bar` scopes `$bar` as a regular PHP variable, etc.