### PR TITLE
fix: make embedded SQL heredocs and nowdocs PHP-aware around inner SQL segments

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1933,6 +1933,9 @@
         'name': 'meta.embedded.sql'
         'patterns': [
           {
+            'include': '#sql-quoted-strings-heredoc'
+          }
+          {
             'include': '#interpolation'
           }
           {
@@ -3027,6 +3030,39 @@
     # Support both PHP string and regex escaping
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
+  'sql-quoted-strings-heredoc':
+    'patterns': [
+      {
+        'begin': '\''
+        'end': '\''
+        'name': 'string.quoted.single.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'begin': '"'
+        'end': '"'
+        'name': 'string.quoted.double.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'begin': '`'
+        'end': '`'
+        'name': 'string.quoted.other.backtick.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+    ]
   'sql-string-double-quoted':
     'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1933,7 +1933,7 @@
         'name': 'meta.embedded.sql'
         'patterns': [
           {
-            'include': '#sql-quoted-strings-heredoc'
+            'include': '#sql-delimited-segments-heredoc'
           }
           {
             'include': '#interpolation'
@@ -2213,6 +2213,9 @@
             'name': 'keyword.operator.nowdoc.php'
         'name': 'meta.embedded.sql'
         'patterns': [
+          {
+            'include': '#sql-delimited-segments-nowdoc'
+          }
           {
             'include': 'source.sql'
           }
@@ -3030,11 +3033,17 @@
     # Support both PHP string and regex escaping
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
-  'sql-quoted-strings-heredoc':
+  'sql-delimited-segments-heredoc':
     'patterns': [
       {
         'begin': '\''
-        'end': '\''
+        'end': '(\')|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.single.sql'
         'patterns': [
           {
@@ -3044,7 +3053,13 @@
       }
       {
         'begin': '"'
-        'end': '"'
+        'end': '(")|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.double.sql'
         'patterns': [
           {
@@ -3054,13 +3069,131 @@
       }
       {
         'begin': '`'
-        'end': '`'
+        'end': '(`)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.other.backtick.sql'
         'patterns': [
           {
             'include': '#interpolation_double_quoted'
           }
         ]
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'end': '(\\*/)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+        'name': 'comment.block'
+        'patterns': [
+          {
+            'include': '#sql-delimited-segments-heredoc'
+          }
+        ]
+      }
+      {
+        'begin': '%\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.other.quoted.brackets.sql'
+      }
+      {
+        'begin': '%r\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.regexp.modr.sql'
+      }
+    ]
+  'sql-delimited-segments-nowdoc':
+    'patterns': [
+      {
+        'begin': '\''
+        'end': '(\')|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.single.sql'
+      }
+      {
+        'begin': '"'
+        'end': '(")|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.double.sql'
+      }
+      {
+        'begin': '`'
+        'end': '(`)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.other.backtick.sql'
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'end': '(\\*/)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+        'name': 'comment.block'
+        'patterns': [
+          {
+            'include': '#sql-delimited-segments-nowdoc'
+          }
+        ]
+      }
+      {
+        'begin': '%\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.other.quoted.brackets.sql'
+      }
+      {
+        'begin': '%r\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.regexp.modr.sql'
       }
     ]
   'sql-string-double-quoted':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4019,6 +4019,24 @@ describe 'PHP grammar', ->
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize interpolation inside quoted SQL segments in a heredoc', ->
+    lines = grammar.tokenizeLines '''
+      $schema = 'test';
+      $id = 1;
+      $sql = <<<SQL
+          SELECT * FROM `{$schema}`.`test` WHERE `id` = '$id';
+      SQL;
+    '''
+
+    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql']
+    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
+    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php']
+    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php']
+    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+
   it 'should tokenize a nowdoc with embedded SQL correctly', ->
     lines = grammar.tokenizeLines '''
       $a = <<<'SQL'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4028,14 +4028,52 @@ describe 'PHP grammar', ->
       SQL;
     '''
 
-    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql']
+    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
     expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
     expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php']
-    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
     expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php']
-    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
+
+  it 'should stop unclosed embedded SQL segments at a heredoc terminator', ->
+    cases = [
+      {
+        opener: '/*'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        opener: '"'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '\''
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%{'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%r{'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+    ]
+
+    for {opener, scopes} in cases
+      lines = grammar.tokenizeLines """
+        $e = <<<SQL
+        SELECT #{opener}
+        SQL;
+        $next = 1;
+      """
+
+      expect(lines[1][2]).toEqual value: opener, scopes: scopes
+      expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[3][1]).toEqual value: 'next', scopes: ['source.php', 'variable.other.php']
 
   it 'should tokenize a nowdoc with embedded SQL correctly', ->
     lines = grammar.tokenizeLines '''
@@ -4069,6 +4107,44 @@ describe 'PHP grammar', ->
     expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+  it 'should stop unclosed embedded SQL segments at a nowdoc terminator', ->
+    cases = [
+      {
+        opener: '/*'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        opener: '"'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '\''
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%{'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%r{'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+    ]
+
+    for {opener, scopes} in cases
+      lines = grammar.tokenizeLines """
+        $e = <<<'SQL'
+        SELECT #{opener}
+        SQL;
+        $next = 1;
+      """
+
+      expect(lines[1][2]).toEqual value: opener, scopes: scopes
+      expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[3][1]).toEqual value: 'next', scopes: ['source.php', 'variable.other.php']
 
   it 'should tokenize a heredoc with embedded DQL correctly', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
Closes #21. Makes SQL heredocs and nowdocs use PHP-aware handling for inner quoted/backticked SQL segments, so interpolation inside them works correctly.

This also addresses a related recovery bug where an unclosed inner SQL segment can swallow the heredoc/nowdoc terminator instead of returning control to PHP, for example:

```php
<?php

$e = <<<SQL
SELECT /*
SQL;

$next = 1;
```

Actual: the SQL block comment stays open, so `SQL;` and the following PHP are tokenized as SQL content.

Expected: `SQL;` ends the heredoc and `$next = 1;` is tokenized as normal PHP:

<img width="120" alt="image" src="https://github.com/user-attachments/assets/2c36da50-6a12-4318-90c7-7652cd1a0b7b" />
<img width="110" alt="image" src="https://github.com/user-attachments/assets/93c613cc-98a7-4ee7-93a5-4b8697809bff" />


Other examples:

```php
<?php

$e = <<<SQL
SELECT "
SQL;

$next = 1;
```
<img width="110" alt="image" src="https://github.com/user-attachments/assets/e2cf28f9-6790-4996-a0bd-f612936f8f1b" />

<img width="110" alt="image" src="https://github.com/user-attachments/assets/3b7a3a85-db02-4b0d-be76-ce51822a311d" />


```php
<?php

$e = <<<SQL
SELECT '
SQL;

$next = 1;
```
<img width="110" alt="image" src="https://github.com/user-attachments/assets/bf2033fe-4b64-4b61-9590-67eb38ffcf00" />

<img width="100" alt="image" src="https://github.com/user-attachments/assets/97eaa836-c8f4-4a8b-bcf9-f85601dc722d" />
