### PR TITLE
fix: stop embedded SQL segments from bleeding across PHP string boundaries

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3058,6 +3058,26 @@
         'name': 'constant.character.escape.php'
       }
       {
+        # Unclosed bracketed identifiers must be captured to avoid them eating the remainder of the PHP script
+        'match': '\\[(?=((\\\\")|[^\\]"])*("|$))'
+        'name': 'text.bracketed.unclosed.sql'
+      }
+      {
+        # Unclosed block comments must be captured to avoid them eating the remainder of the PHP script
+        'match': '/\\*(?=((\\\\")|(?:(?!\\*/|").))*("|$))'
+        'name': 'comment.block.unclosed.sql'
+      }
+      {
+        # Unclosed %{...} strings must be captured to avoid them eating the remainder of the PHP script
+        'match': '%\\{(?=((\\\\")|[^}"])*("|$))'
+        'name': 'string.other.quoted.brackets.unclosed.sql'
+      }
+      {
+        # Unclosed %r{...} regexes must be captured to avoid them eating the remainder of the PHP script
+        'match': '%r\\{(?=((\\\\")|[^}"])*("|$))'
+        'name': 'string.regexp.modr.unclosed.sql'
+      }
+      {
         # Unclosed strings must be captured to avoid them eating the remainder of the PHP script
         # Sample case: $sql = "SELECT * FROM bar WHERE foo = \'" . $variable . "\'"'
         'match': '\'(?=((\\\\\')|[^\'"])*("|$))'
@@ -3125,6 +3145,26 @@
       {
         'match': '\\\\[\\\\\'`"]'
         'name': 'constant.character.escape.php'
+      }
+      {
+        # Unclosed bracketed identifiers must be captured to avoid them eating the remainder of the PHP script
+        'match': '\\[(?=((\\\\\')|[^\\]\'])*(\'|$))'
+        'name': 'text.bracketed.unclosed.sql'
+      }
+      {
+        # Unclosed block comments must be captured to avoid them eating the remainder of the PHP script
+        'match': '/\\*(?=((\\\\\')|(?:(?!\\*/|\').))*(\'|$))'
+        'name': 'comment.block.unclosed.sql'
+      }
+      {
+        # Unclosed %{...} strings must be captured to avoid them eating the remainder of the PHP script
+        'match': '%\\{(?=((\\\\\')|[^}\'])*(\'|$))'
+        'name': 'string.other.quoted.brackets.unclosed.sql'
+      }
+      {
+        # Unclosed %r{...} regexes must be captured to avoid them eating the remainder of the PHP script
+        'match': '%r\\{(?=((\\\\\')|[^}\'])*(\'|$))'
+        'name': 'string.regexp.modr.unclosed.sql'
       }
       {
         # Unclosed strings must be captured to avoid them eating the remainder of the PHP script

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3578,6 +3578,160 @@ describe 'PHP grammar', ->
       expect(lines[1][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql']
       expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
 
+  it 'should keep closed embedded SQL bracket, comment and percent segments tokenized by source.sql', ->
+    cases = [
+      {
+        line: '$sql = "SELECT [db]";'
+        tokenIndex: 8
+        token:
+          value: '[db]'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'text.bracketed']
+      }
+      {
+        line: "$sql = 'UPDATE [db]';"
+        tokenIndex: 8
+        token:
+          value: '[db]'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'text.bracketed']
+      }
+      {
+        line: '$sql = "SELECT /* ok */";'
+        tokenIndex: 8
+        token:
+          value: '/*'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        line: "$sql = 'UPDATE /* ok */';"
+        tokenIndex: 8
+        token:
+          value: '/*'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        line: '$sql = "SELECT %{ok}";'
+        tokenIndex: 8
+        token:
+          value: '%{'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        line: "$sql = 'UPDATE %{ok}';"
+        tokenIndex: 8
+        token:
+          value: '%{'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        line: '$sql = "SELECT %r{ok}";'
+        tokenIndex: 8
+        token:
+          value: '%r{'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        line: "$sql = 'UPDATE %r{ok}';"
+        tokenIndex: 8
+        token:
+          value: '%r{'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+    ]
+
+    for {line, tokenIndex, token} in cases
+      {tokens} = grammar.tokenizeLine line
+      expect(tokens[tokenIndex]).toEqual token
+
+  it 'should recover PHP concatenation after unclosed embedded SQL bracket, comment and percent segments', ->
+    cases = [
+      {
+        line: '$sql = "SELECT [".$x."]";'
+        tokenIndex: 8
+        token:
+          value: '['
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'text.bracketed.unclosed.sql']
+        stringEnd: '"'
+      }
+      {
+        line: "$sql = 'UPDATE ['.$x.']';"
+        tokenIndex: 8
+        token:
+          value: '['
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'text.bracketed.unclosed.sql']
+        stringEnd: '\''
+      }
+      {
+        line: '$sql = "SELECT /*".$x."*/";'
+        tokenIndex: 8
+        token:
+          value: '/*'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'comment.block.unclosed.sql']
+        stringEnd: '"'
+      }
+      {
+        line: "$sql = 'UPDATE /*'.$x.'*/';"
+        tokenIndex: 8
+        token:
+          value: '/*'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'comment.block.unclosed.sql']
+        stringEnd: '\''
+      }
+      {
+        line: '$sql = "SELECT %{".$x."}";'
+        tokenIndex: 8
+        token:
+          value: '%{'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.unclosed.sql']
+        stringEnd: '"'
+      }
+      {
+        line: "$sql = 'UPDATE %{'.$x.'}';"
+        tokenIndex: 8
+        token:
+          value: '%{'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.unclosed.sql']
+        stringEnd: '\''
+      }
+      {
+        line: '$sql = "SELECT %r{".$x."}";'
+        tokenIndex: 8
+        token:
+          value: '%r{'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.unclosed.sql']
+        stringEnd: '"'
+      }
+      {
+        line: "$sql = 'UPDATE %r{'.$x.'}';"
+        tokenIndex: 8
+        token:
+          value: '%r{'
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.unclosed.sql']
+        stringEnd: '\''
+      }
+    ]
+
+    for {line, tokenIndex, token, stringEnd} in cases
+      {tokens} = grammar.tokenizeLine line
+      expect(tokens[tokenIndex]).toEqual token
+      expect(tokens[tokenIndex + 1]).toEqual value: stringEnd, scopes: ['source.php', token.scopes[1], 'punctuation.definition.string.end.php']
+      expect(tokens[tokenIndex + 2]).toEqual value: '.', scopes: ['source.php', 'keyword.operator.string.php']
+      expect(tokens[tokenIndex + 3]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[tokenIndex + 4]).toEqual value: 'x', scopes: ['source.php', 'variable.other.php']
+
+  it 'should recover PHP array access after an unclosed embedded SQL bracketed identifier', ->
+    {tokens} = grammar.tokenizeLine '$findloginfeild = "SELECT * FROM [".$_POST[\'getdb\']."].[dbo].[tabl1] WHERE [column1] = \'PASSWORD\'";'
+
+    expect(tokens[12]).toEqual value: '[', scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'text.bracketed.unclosed.sql']
+    expect(tokens[13]).toEqual value: '"', scopes: ['source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
+    expect(tokens[14]).toEqual value: '.', scopes: ['source.php', 'keyword.operator.string.php']
+    expect(tokens[15]).toEqual value: '$', scopes: ['source.php', 'variable.other.global.php', 'punctuation.definition.variable.php']
+    expect(tokens[16]).toEqual value: '_POST', scopes: ['source.php', 'variable.other.global.php']
+    expect(tokens[17]).toEqual value: '[', scopes: ['source.php', 'punctuation.section.array.begin.php']
+    expect(tokens[18]).toEqual value: '\'', scopes: ['source.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+    expect(tokens[19]).toEqual value: 'getdb', scopes: ['source.php', 'string.quoted.single.php']
+    expect(tokens[20]).toEqual value: '\'', scopes: ['source.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+    expect(tokens[21]).toEqual value: ']', scopes: ['source.php', 'punctuation.section.array.end.php']
+
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3650,7 +3650,9 @@ describe 'PHP grammar', ->
         token:
           value: '['
           scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'text.bracketed.unclosed.sql']
-        stringEnd: '"'
+        stringEndToken:
+          value: '"'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: "$sql = 'UPDATE ['.$x.']';"
@@ -3658,7 +3660,9 @@ describe 'PHP grammar', ->
         token:
           value: '['
           scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'text.bracketed.unclosed.sql']
-        stringEnd: '\''
+        stringEndToken:
+          value: '\''
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: '$sql = "SELECT /*".$x."*/";'
@@ -3666,7 +3670,9 @@ describe 'PHP grammar', ->
         token:
           value: '/*'
           scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'comment.block.unclosed.sql']
-        stringEnd: '"'
+        stringEndToken:
+          value: '"'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: "$sql = 'UPDATE /*'.$x.'*/';"
@@ -3674,7 +3680,9 @@ describe 'PHP grammar', ->
         token:
           value: '/*'
           scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'comment.block.unclosed.sql']
-        stringEnd: '\''
+        stringEndToken:
+          value: '\''
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: '$sql = "SELECT %{".$x."}";'
@@ -3682,7 +3690,9 @@ describe 'PHP grammar', ->
         token:
           value: '%{'
           scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.unclosed.sql']
-        stringEnd: '"'
+        stringEndToken:
+          value: '"'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: "$sql = 'UPDATE %{'.$x.'}';"
@@ -3690,7 +3700,9 @@ describe 'PHP grammar', ->
         token:
           value: '%{'
           scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.other.quoted.brackets.unclosed.sql']
-        stringEnd: '\''
+        stringEndToken:
+          value: '\''
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: '$sql = "SELECT %r{".$x."}";'
@@ -3698,7 +3710,9 @@ describe 'PHP grammar', ->
         token:
           value: '%r{'
           scopes: ['source.php', 'string.quoted.double.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.unclosed.sql']
-        stringEnd: '"'
+        stringEndToken:
+          value: '"'
+          scopes: ['source.php', 'string.quoted.double.sql.php', 'punctuation.definition.string.end.php']
       }
       {
         line: "$sql = 'UPDATE %r{'.$x.'}';"
@@ -3706,14 +3720,16 @@ describe 'PHP grammar', ->
         token:
           value: '%r{'
           scopes: ['source.php', 'string.quoted.single.sql.php', 'source.sql.embedded.php', 'string.regexp.modr.unclosed.sql']
-        stringEnd: '\''
+        stringEndToken:
+          value: '\''
+          scopes: ['source.php', 'string.quoted.single.sql.php', 'punctuation.definition.string.end.php']
       }
     ]
 
-    for {line, tokenIndex, token, stringEnd} in cases
+    for {line, tokenIndex, token, stringEnd, stringEndToken} in cases
       {tokens} = grammar.tokenizeLine line
       expect(tokens[tokenIndex]).toEqual token
-      expect(tokens[tokenIndex + 1]).toEqual value: stringEnd, scopes: ['source.php', token.scopes[1], 'punctuation.definition.string.end.php']
+      expect(tokens[tokenIndex + 1]).toEqual stringEndToken
       expect(tokens[tokenIndex + 2]).toEqual value: '.', scopes: ['source.php', 'keyword.operator.string.php']
       expect(tokens[tokenIndex + 3]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[tokenIndex + 4]).toEqual value: 'x', scopes: ['source.php', 'variable.other.php']


### PR DESCRIPTION
Closes #14 square-bracket SQL bleed, and adds the same PHP-boundary protection for block comments and percent-delimited segments discovered during the fix.

Before:

<img width="600" alt="explorer_2026-03-13--08-53-57--444" src="https://github.com/user-attachments/assets/8b6d92b7-5585-4be2-bc4d-3a628278ee17" />


After:

<img width="600" alt="explorer_2026-03-13--08-54-09--714" src="https://github.com/user-attachments/assets/1c21b535-8e57-4686-b22b-8bed2630ec4b" />
