### PR TITLE
fix: normalize embedded SQL wrapper scopes across PHP string types

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1923,7 +1923,7 @@
             'name': 'keyword.operator.heredoc.php'
           '5':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'contentName': 'source.sql'
+        'contentName': 'source.sql.embedded.php'
         'end': '^\\s*(\\3)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':
@@ -2204,7 +2204,7 @@
             'name': 'keyword.operator.nowdoc.php'
           '3':
             'name': 'invalid.illegal.trailing-whitespace.php'
-        'contentName': 'source.sql'
+        'contentName': 'source.sql.embedded.php'
         'end': '^\\s*(\\2)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}])'
         'endCaptures':
           '0':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1933,6 +1933,9 @@
         'name': 'meta.embedded.sql'
         'patterns': [
           {
+            'include': '#sql-quoted-strings-heredoc'
+          }
+          {
             'include': '#interpolation'
           }
           {
@@ -3027,6 +3030,39 @@
     # Support both PHP string and regex escaping
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
+  'sql-quoted-strings-heredoc':
+    'patterns': [
+      {
+        'begin': '\''
+        'end': '\''
+        'name': 'string.quoted.single.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'begin': '"'
+        'end': '"'
+        'name': 'string.quoted.double.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+      {
+        'begin': '`'
+        'end': '`'
+        'name': 'string.quoted.other.backtick.sql'
+        'patterns': [
+          {
+            'include': '#interpolation_double_quoted'
+          }
+        ]
+      }
+    ]
   'sql-string-double-quoted':
     'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2475,6 +2475,7 @@
       }
       {
         'begin': '{(?=\\$.*?})'
+        'name': 'meta.embedded.interpolation.php'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.variable.php'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3198,14 +3198,18 @@
       }
     ]
   'sql-string-double-quoted':
-    'begin': '"\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '(")\\s*(?=(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
+        'name': 'string.quoted.double.php'
+      '1':
         'name': 'punctuation.definition.string.begin.php'
     'contentName': 'source.sql.embedded.php'
-    'end': '"'
+    'end': '(")'
     'endCaptures':
       '0':
+        'name': 'string.quoted.double.php'
+      '1':
         'name': 'punctuation.definition.string.end.php'
     'name': 'meta.embedded.sql'
     'patterns': [
@@ -3267,14 +3271,18 @@
       }
     ]
   'sql-string-single-quoted':
-    'begin': '\'\\s*(?=(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
+    'begin': '(\')\\s*(?=(?:SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|AND|WITH)\\b)'
     'beginCaptures':
       '0':
+        'name': 'string.quoted.single.php'
+      '1':
         'name': 'punctuation.definition.string.begin.php'
     'contentName': 'source.sql.embedded.php'
-    'end': '\''
+    'end': '(\')'
     'endCaptures':
       '0':
+        'name': 'string.quoted.single.php'
+      '1':
         'name': 'punctuation.definition.string.end.php'
     'name': 'meta.embedded.sql'
     'patterns': [

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -3207,7 +3207,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.php'
-    'name': 'string.quoted.double.sql.php'
+    'name': 'meta.embedded.sql'
     'patterns': [
       {
         'match': '(#)(\\\\"|[^"])*(?="|$)'
@@ -3276,7 +3276,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.php'
-    'name': 'string.quoted.single.sql.php'
+    'name': 'meta.embedded.sql'
     'patterns': [
       {
         'match': '(#)(\\\\\'|[^\'])*(?=\'|$)'

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1933,7 +1933,7 @@
         'name': 'meta.embedded.sql'
         'patterns': [
           {
-            'include': '#sql-quoted-strings-heredoc'
+            'include': '#sql-delimited-segments-heredoc'
           }
           {
             'include': '#interpolation'
@@ -2213,6 +2213,9 @@
             'name': 'keyword.operator.nowdoc.php'
         'name': 'meta.embedded.sql'
         'patterns': [
+          {
+            'include': '#sql-delimited-segments-nowdoc'
+          }
           {
             'include': 'source.sql'
           }
@@ -3030,11 +3033,17 @@
     # Support both PHP string and regex escaping
     'match': '\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)'
     'name': 'constant.character.escape.php'
-  'sql-quoted-strings-heredoc':
+  'sql-delimited-segments-heredoc':
     'patterns': [
       {
         'begin': '\''
-        'end': '\''
+        'end': '(\')|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.single.sql'
         'patterns': [
           {
@@ -3044,7 +3053,13 @@
       }
       {
         'begin': '"'
-        'end': '"'
+        'end': '(")|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.double.sql'
         'patterns': [
           {
@@ -3054,13 +3069,131 @@
       }
       {
         'begin': '`'
-        'end': '`'
+        'end': '(`)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
         'name': 'string.quoted.other.backtick.sql'
         'patterns': [
           {
             'include': '#interpolation_double_quoted'
           }
         ]
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'end': '(\\*/)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+        'name': 'comment.block'
+        'patterns': [
+          {
+            'include': '#sql-delimited-segments-heredoc'
+          }
+        ]
+      }
+      {
+        'begin': '%\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.other.quoted.brackets.sql'
+      }
+      {
+        'begin': '%r\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.regexp.modr.sql'
+      }
+    ]
+  'sql-delimited-segments-nowdoc':
+    'patterns': [
+      {
+        'begin': '\''
+        'end': '(\')|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.single.sql'
+      }
+      {
+        'begin': '"'
+        'end': '(")|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.double.sql'
+      }
+      {
+        'begin': '`'
+        'end': '(`)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'name': 'string.quoted.other.backtick.sql'
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.sql'
+        'end': '(\\*/)|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.comment.sql'
+        'name': 'comment.block'
+        'patterns': [
+          {
+            'include': '#sql-delimited-segments-nowdoc'
+          }
+        ]
+      }
+      {
+        'begin': '%\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.other.quoted.brackets.sql'
+      }
+      {
+        'begin': '%r\\{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.sql'
+        'end': '(\\})|(?=^\\s*(?:SQL|DQL)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.string.end.sql'
+        'name': 'string.regexp.modr.sql'
       }
     ]
   'sql-string-double-quoted':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4019,6 +4019,24 @@ describe 'PHP grammar', ->
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize interpolation inside quoted SQL segments in a heredoc', ->
+    lines = grammar.tokenizeLines '''
+      $schema = 'test';
+      $id = 1;
+      $sql = <<<SQL
+          SELECT * FROM `{$schema}`.`test` WHERE `id` = '$id';
+      SQL;
+    '''
+
+    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql']
+    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
+    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php']
+    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php']
+    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+
   it 'should tokenize a nowdoc with embedded SQL correctly', ->
     lines = grammar.tokenizeLines '''
       $a = <<<'SQL'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4003,19 +4003,19 @@ describe 'PHP grammar', ->
     expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'punctuation.definition.string.php']
     expect(lines[0][6]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.heredoc.php']
     expect(lines[1][0].value).toEqual 'SELECT'
-    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][1].value).toEqual ' '
-    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][2].value).toEqual '*'
-    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][3].value).toEqual ' '
-    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][4].value).toEqual 'FROM'
-    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][5].value).toEqual ' '
-    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][6].value).toEqual 'table'
-    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
@@ -4028,36 +4028,71 @@ describe 'PHP grammar', ->
       SQL;
     '''
 
-    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
-    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
-    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
-    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php']
-    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
-    expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
-    expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php']
-    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
+    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
+    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
+    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php']
+    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+    expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php']
+    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
+
+  it 'should use the same embedded SQL content scope for heredocs as double-quoted SQL strings', ->
+    lines = grammar.tokenizeLines '''
+      $maxId = 10;
+      $sql = "SELECT d.id FROM my_table d WHERE d.id BETWEEN 1 AND $maxId AND my_custom_func(d.name) > 10";
+      $sql = <<<SQL
+          SELECT d.id FROM my_table d WHERE d.id BETWEEN 1 AND $maxId AND my_custom_func(d.name) > 10
+      SQL;
+    '''
+
+    findToken = (tokens, value, scope) ->
+      for token in tokens when token.value is value and scope in token.scopes
+        return token
+
+    quotedAlias = findToken lines[1], 'd', 'constant.other.database-name.sql'
+    heredocAlias = findToken lines[3], 'd', 'constant.other.database-name.sql'
+    quotedIdentifier = findToken lines[1], 'id', 'constant.other.table-name.sql'
+    heredocIdentifier = findToken lines[3], 'id', 'constant.other.table-name.sql'
+    quotedInterpolation = findToken lines[1], 'maxId', 'variable.other.php'
+    heredocInterpolation = findToken lines[3], 'maxId', 'variable.other.php'
+
+    expect(findToken(lines[1], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'source.sql.embedded.php'
+    expect(findToken(lines[3], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'source.sql.embedded.php'
+    expect(quotedAlias.scopes).toContain 'source.sql.embedded.php'
+    expect(heredocAlias.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedAlias.scopes).toContain 'constant.other.database-name.sql'
+    expect(heredocAlias.scopes).toContain 'constant.other.database-name.sql'
+    expect(quotedIdentifier.scopes).toContain 'source.sql.embedded.php'
+    expect(heredocIdentifier.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedIdentifier.scopes).toContain 'constant.other.table-name.sql'
+    expect(heredocIdentifier.scopes).toContain 'constant.other.table-name.sql'
+    expect(quotedInterpolation.scopes).toContain 'source.sql.embedded.php'
+    expect(heredocInterpolation.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedInterpolation.scopes).toContain 'variable.other.php'
+    expect(heredocInterpolation.scopes).toContain 'variable.other.php'
 
   it 'should stop unclosed embedded SQL segments at a heredoc terminator', ->
     cases = [
       {
         opener: '/*'
-        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.block', 'punctuation.definition.comment.sql']
       }
       {
         opener: '"'
-        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '\''
-        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '%{'
-        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '%r{'
-        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
       }
     ]
 
@@ -4092,19 +4127,19 @@ describe 'PHP grammar', ->
     expect(lines[0][7]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.nowdoc.php']
     expect(lines[0][8]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php']
     expect(lines[1][0].value).toEqual 'SELECT'
-    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][1].value).toEqual ' '
-    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][2].value).toEqual '*'
-    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][3].value).toEqual ' '
-    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][4].value).toEqual 'FROM'
-    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][5].value).toEqual ' '
-    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][6].value).toEqual 'table'
-    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
@@ -4112,23 +4147,23 @@ describe 'PHP grammar', ->
     cases = [
       {
         opener: '/*'
-        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.block', 'punctuation.definition.comment.sql']
       }
       {
         opener: '"'
-        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '\''
-        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '%{'
-        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
       }
       {
         opener: '%r{'
-        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
       }
     ]
 
@@ -4161,19 +4196,19 @@ describe 'PHP grammar', ->
     expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'punctuation.definition.string.php']
     expect(lines[0][6]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.heredoc.php']
     expect(lines[1][0].value).toEqual 'SELECT'
-    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][1].value).toEqual ' '
-    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][2].value).toEqual '*'
-    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][3].value).toEqual ' '
-    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][4].value).toEqual 'FROM'
-    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][5].value).toEqual ' '
-    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][6].value).toEqual 'table'
-    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[2][0]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
@@ -4194,19 +4229,19 @@ describe 'PHP grammar', ->
     expect(lines[0][7]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php', 'keyword.operator.nowdoc.php']
     expect(lines[0][8]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.begin.php']
     expect(lines[1][0].value).toEqual 'SELECT'
-    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][0].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][1].value).toEqual ' '
-    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][1].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][2].value).toEqual '*'
-    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][2].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][3].value).toEqual ' '
-    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][3].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][4].value).toEqual 'FROM'
-    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][4].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][5].value).toEqual ' '
-    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][5].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[1][6].value).toEqual 'table'
-    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
+    expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql.embedded.php']
     expect(lines[2][0]).toEqual value: 'DQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3575,25 +3575,30 @@ describe 'PHP grammar', ->
     expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
   it 'should tokenize embedded SQL in a string', ->
-    delimsByScope =
-      'string.quoted.double.sql.php': '"'
-      'string.quoted.single.sql.php': "'"
-
-    for scope, delim of delimsByScope
+    for delim in ['"', "'"]
       {tokens} = grammar.tokenizeLine "#{delim}SELECT something#{delim}"
 
-      expect(tokens[0]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.begin.php']
-      expect(tokens[1]).toEqual value: 'SELECT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'keyword.other.DML.sql']
-      expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', scope, 'source.sql.embedded.php']
-      expect(tokens[3]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+      expect(tokens[0]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.begin.php']
+      expect(tokens[1]).toEqual value: 'SELECT', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'keyword.other.DML.sql']
+      expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php']
+      expect(tokens[3]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
 
       lines = grammar.tokenizeLines """
         #{delim}SELECT something
         -- uh oh a comment SELECT#{delim}
       """
-      expect(lines[1][0]).toEqual value: '--', scopes: ['source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
-      expect(lines[1][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['source.php', scope, 'source.sql.embedded.php', 'comment.line.double-dash.sql']
-      expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', scope, 'punctuation.definition.string.end.php']
+      expect(lines[1][0]).toEqual value: '--', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
+      expect(lines[1][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.line.double-dash.sql']
+      expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
+
+  it 'should tokenize braced interpolation inside quoted embedded SQL', ->
+    {tokens} = grammar.tokenizeLine '"SELECT `{$schema}` FROM `test`";'
+
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.begin.php']
+    expect(tokens[4]).toEqual value: '{', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'punctuation.definition.variable.php']
+    expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[6]).toEqual value: 'schema', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php']
+    expect(tokens[15]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
 
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"
@@ -4054,7 +4059,7 @@ describe 'PHP grammar', ->
     expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php']
     expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
 
-  it 'should use the same embedded SQL content scope for heredocs as double-quoted SQL strings', ->
+  it 'should scope quoted embedded SQL content like heredoc SQL content', ->
     lines = grammar.tokenizeLines '''
       $maxId = 10;
       $sql = "SELECT d.id FROM my_table d WHERE d.id BETWEEN 1 AND $maxId AND my_custom_func(d.name) > 10";
@@ -4076,18 +4081,29 @@ describe 'PHP grammar', ->
 
     expect(findToken(lines[1], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'source.sql.embedded.php'
     expect(findToken(lines[3], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'source.sql.embedded.php'
+    expect(findToken(lines[1], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'meta.embedded.sql'
+    expect(findToken(lines[3], 'SELECT', 'keyword.other.DML.sql').scopes).toContain 'meta.embedded.sql'
     expect(quotedAlias.scopes).toContain 'source.sql.embedded.php'
     expect(heredocAlias.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedAlias.scopes).toContain 'meta.embedded.sql'
+    expect(heredocAlias.scopes).toContain 'meta.embedded.sql'
     expect(quotedAlias.scopes).toContain 'constant.other.database-name.sql'
     expect(heredocAlias.scopes).toContain 'constant.other.database-name.sql'
     expect(quotedIdentifier.scopes).toContain 'source.sql.embedded.php'
     expect(heredocIdentifier.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedIdentifier.scopes).toContain 'meta.embedded.sql'
+    expect(heredocIdentifier.scopes).toContain 'meta.embedded.sql'
     expect(quotedIdentifier.scopes).toContain 'constant.other.table-name.sql'
     expect(heredocIdentifier.scopes).toContain 'constant.other.table-name.sql'
     expect(quotedInterpolation.scopes).toContain 'source.sql.embedded.php'
     expect(heredocInterpolation.scopes).toContain 'source.sql.embedded.php'
+    expect(quotedInterpolation.scopes).toContain 'meta.embedded.sql'
+    expect(heredocInterpolation.scopes).toContain 'meta.embedded.sql'
     expect(quotedInterpolation.scopes).toContain 'variable.other.php'
     expect(heredocInterpolation.scopes).toContain 'variable.other.php'
+    expect(quotedAlias.scopes).to.not.include 'string.quoted.double.sql.php'
+    expect(quotedIdentifier.scopes).to.not.include 'string.quoted.double.sql.php'
+    expect(quotedInterpolation.scopes).to.not.include 'string.quoted.double.sql.php'
 
   it 'should stop unclosed embedded SQL segments at a heredoc terminator', ->
     cases = [

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4028,14 +4028,52 @@ describe 'PHP grammar', ->
       SQL;
     '''
 
-    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql']
+    expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
     expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
     expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.other.backtick.sql', 'variable.other.php']
-    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
     expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'variable.other.php']
-    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql']
+    expect(lines[3][29]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.end.sql']
+
+  it 'should stop unclosed embedded SQL segments at a heredoc terminator', ->
+    cases = [
+      {
+        opener: '/*'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        opener: '"'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '\''
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%{'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%r{'
+        scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+    ]
+
+    for {opener, scopes} in cases
+      lines = grammar.tokenizeLines """
+        $e = <<<SQL
+        SELECT #{opener}
+        SQL;
+        $next = 1;
+      """
+
+      expect(lines[1][2]).toEqual value: opener, scopes: scopes
+      expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[3][1]).toEqual value: 'next', scopes: ['source.php', 'variable.other.php']
 
   it 'should tokenize a nowdoc with embedded SQL correctly', ->
     lines = grammar.tokenizeLines '''
@@ -4069,6 +4107,44 @@ describe 'PHP grammar', ->
     expect(lines[1][6].scopes).toContainAll ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql']
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+  it 'should stop unclosed embedded SQL segments at a nowdoc terminator', ->
+    cases = [
+      {
+        opener: '/*'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'comment.block', 'punctuation.definition.comment.sql']
+      }
+      {
+        opener: '"'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.double.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '\''
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%{'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.other.quoted.brackets.sql', 'punctuation.definition.string.begin.sql']
+      }
+      {
+        opener: '%r{'
+        scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'source.sql', 'string.regexp.modr.sql', 'punctuation.definition.string.begin.sql']
+      }
+    ]
+
+    for {opener, scopes} in cases
+      lines = grammar.tokenizeLines """
+        $e = <<<'SQL'
+        SELECT #{opener}
+        SQL;
+        $next = 1;
+      """
+
+      expect(lines[1][2]).toEqual value: opener, scopes: scopes
+      expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+      expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+      expect(lines[3][0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(lines[3][1]).toEqual value: 'next', scopes: ['source.php', 'variable.other.php']
 
   it 'should tokenize a heredoc with embedded DQL correctly', ->
     lines = grammar.tokenizeLines '''

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3396,6 +3396,23 @@ describe 'PHP grammar', ->
       expect(lines[1][2]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
 
   describe 'string escape sequences', ->
+    it 'tokenizes braced interpolation as embedded PHP code', ->
+      {tokens} = grammar.tokenizeLine '"test {$array[\'x\']}";'
+
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.php', 'string.quoted.double.php', 'punctuation.definition.string.begin.php']
+      expect(tokens[1]).toEqual value: 'test ', scopes: ['source.php', 'string.quoted.double.php']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'punctuation.definition.variable.php']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[4]).toEqual value: 'array', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'variable.other.php']
+      expect(tokens[5]).toEqual value: '[', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'punctuation.section.array.begin.php']
+      expect(tokens[6]).toEqual value: '\'', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'string.quoted.single.php', 'punctuation.definition.string.begin.php']
+      expect(tokens[7]).toEqual value: 'x', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'string.quoted.single.php']
+      expect(tokens[8]).toEqual value: '\'', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'string.quoted.single.php', 'punctuation.definition.string.end.php']
+      expect(tokens[9]).toEqual value: ']', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'punctuation.section.array.end.php']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.php', 'string.quoted.double.php', 'meta.embedded.interpolation.php', 'punctuation.definition.variable.php']
+      expect(tokens[11]).toEqual value: '"', scopes: ['source.php', 'string.quoted.double.php', 'punctuation.definition.string.end.php']
+      expect(tokens[12]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
     it 'tokenizes escaped octal sequences', ->
       {tokens} = grammar.tokenizeLine '"test \\007 test";'
 
@@ -4029,9 +4046,9 @@ describe 'PHP grammar', ->
     '''
 
     expect(lines[3][7]).toEqual value: '`', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.string.begin.sql']
-    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'punctuation.definition.variable.php']
-    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php', 'punctuation.definition.variable.php']
-    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'variable.other.php']
+    expect(lines[3][8]).toEqual value: '{', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'punctuation.definition.variable.php']
+    expect(lines[3][9]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(lines[3][10]).toEqual value: 'schema', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php']
     expect(lines[3][26]).toEqual value: '\'', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'punctuation.definition.string.begin.sql']
     expect(lines[3][27]).toEqual value: '$', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(lines[3][28]).toEqual value: 'id', scopes: ['source.php', 'string.unquoted.heredoc.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.single.sql', 'variable.other.php']

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -3578,10 +3578,14 @@ describe 'PHP grammar', ->
     for delim in ['"', "'"]
       {tokens} = grammar.tokenizeLine "#{delim}SELECT something#{delim}"
 
-      expect(tokens[0]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.begin.php']
+      quoteScope = if delim is '"' then 'string.quoted.double.php' else 'string.quoted.single.php'
+      beginScope = 'punctuation.definition.string.begin.php'
+      endScope = 'punctuation.definition.string.end.php'
+
+      expect(tokens[0]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', quoteScope, beginScope]
       expect(tokens[1]).toEqual value: 'SELECT', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'keyword.other.DML.sql']
       expect(tokens[2]).toEqual value: ' something', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php']
-      expect(tokens[3]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
+      expect(tokens[3]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', quoteScope, endScope]
 
       lines = grammar.tokenizeLines """
         #{delim}SELECT something
@@ -3589,16 +3593,16 @@ describe 'PHP grammar', ->
       """
       expect(lines[1][0]).toEqual value: '--', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.line.double-dash.sql', 'punctuation.definition.comment.sql']
       expect(lines[1][1]).toEqual value: ' uh oh a comment SELECT', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'comment.line.double-dash.sql']
-      expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
+      expect(lines[1][2]).toEqual value: delim, scopes: ['source.php', 'meta.embedded.sql', quoteScope, endScope]
 
   it 'should tokenize braced interpolation inside quoted embedded SQL', ->
     {tokens} = grammar.tokenizeLine '"SELECT `{$schema}` FROM `test`";'
 
-    expect(tokens[0]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.begin.php']
+    expect(tokens[0]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'string.quoted.double.php', 'punctuation.definition.string.begin.php']
     expect(tokens[4]).toEqual value: '{', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'punctuation.definition.variable.php']
     expect(tokens[5]).toEqual value: '$', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php', 'punctuation.definition.variable.php']
     expect(tokens[6]).toEqual value: 'schema', scopes: ['source.php', 'meta.embedded.sql', 'source.sql.embedded.php', 'string.quoted.other.backtick.sql', 'meta.embedded.interpolation.php', 'variable.other.php']
-    expect(tokens[15]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'punctuation.definition.string.end.php']
+    expect(tokens[15]).toEqual value: '"', scopes: ['source.php', 'meta.embedded.sql', 'string.quoted.double.php', 'punctuation.definition.string.end.php']
 
   it 'should tokenize single quoted string regex escape characters correctly', ->
     {tokens} = grammar.tokenizeLine "'/[\\\\\\\\]/';"


### PR DESCRIPTION
Closes #23.
It is built on top of #43 and #46, so if this is merged as-is, it also closes #15 and closes #21.

This changes the wrapper scope for embedded SQL in quoted PHP strings from `string.quoted.*.sql.php` to `meta.embedded.sql`, aligning it with the heredoc/nowdoc embedded-SQL path and making theme/editor behavior more consistent.
Beyond more consistent colors, it enables the `bracketPairColorization` VS Code feature to work with any supported brackets in embedded SQL (not just PHP-interpolation brackets which is solved by #43).

Before:
<img width="1319" height="168" alt="image" src="https://github.com/user-attachments/assets/e58910bb-0070-4013-98f3-8cdf65ae235d" />

After:
<img width="1319" height="176" alt="image" src="https://github.com/user-attachments/assets/b14c7ab8-81fe-4cbf-86bc-3edd8c01c090" />