### PR TITLE
fix: Scope invoke-call callee separately

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2591,25 +2591,40 @@
       }
     ]
   'invoke-call':
-    'begin': '(?i)((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(\\()'
+    'begin': '(?i)(((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*))(?=\\s*\\()'
     'beginCaptures':
       '1':
-        'name': 'variable.other.php'
-      '2':
-        'name': 'punctuation.definition.variable.php'
-      '3':
-        'name': 'punctuation.definition.arguments.begin.bracket.round.php'
-    'end': '\\)|(?=\\?>)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.arguments.end.bracket.round.php'
-    'name': 'meta.function-call.invoke.php'
+        'patterns': [
+          {
+            'match': '(?i)((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)'
+            'name': 'meta.function-call.invoke.php'
+            'captures':
+              '1':
+                'name': 'variable.other.php'
+              '2':
+                'name': 'punctuation.definition.variable.php'
+          }
+        ]
+    'end': '(?<=\\))|(?=\\?>)'
     'patterns': [
       {
-        'include': '#named-arguments'
-      }
-      {
-        'include': '$self'
+        'begin': '(\\s*)(\\()'
+        'beginCaptures':
+          '2':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.php'
+        'end': '\\)|(?=\\?>)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.php'
+        'name': 'meta.function-call.php'
+        'patterns': [
+          {
+            'include': '#named-arguments'
+          }
+          {
+            'include': '$self'
+          }
+        ]
       }
     ]
   'namespace':

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -2077,12 +2077,14 @@ describe 'PHP grammar', ->
       expect(tokens[3]).toEqual value: 'apc_store', scopes: ['source.php', 'meta.function-call.php', 'entity.name.function.php']
 
     it 'tokenizes closure calls', ->
-      {tokens} = grammar.tokenizeLine '$callback()'
+      {tokens} = grammar.tokenizeLine '$callback($param)'
 
       expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'meta.function-call.invoke.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(tokens[1]).toEqual value: 'callback', scopes: ['source.php', 'meta.function-call.invoke.php', 'variable.other.php']
-      expect(tokens[2]).toEqual value: '(', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.definition.arguments.begin.bracket.round.php']
-      expect(tokens[3]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(tokens[2]).toEqual value: '(', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.php', 'meta.function-call.php', 'variable.other.php', 'punctuation.definition.variable.php']
+      expect(tokens[4]).toEqual value: 'param', scopes: ['source.php', 'meta.function-call.php', 'variable.other.php']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
 
     it 'tokenizes closure calls with named arguments', ->
       lines = grammar.tokenizeLines '''
@@ -2094,12 +2096,12 @@ describe 'PHP grammar', ->
 
       expect(lines[0][0]).toEqual value: '$', scopes: ['source.php', 'meta.function-call.invoke.php', 'variable.other.php', 'punctuation.definition.variable.php']
       expect(lines[0][1]).toEqual value: 'anonFunc', scopes: ['source.php', 'meta.function-call.invoke.php', 'variable.other.php']
-      expect(lines[0][2]).toEqual value: '(', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.definition.arguments.begin.bracket.round.php']
-      expect(lines[1][1]).toEqual value: 'bar', scopes: ['source.php', 'meta.function-call.invoke.php', 'entity.name.variable.parameter.php']
-      expect(lines[1][2]).toEqual value: ':', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.separator.colon.php']
-      expect(lines[2][1]).toEqual value: 'foo', scopes: ['source.php', 'meta.function-call.invoke.php', 'entity.name.variable.parameter.php']
-      expect(lines[2][2]).toEqual value: ':', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.separator.colon.php']
-      expect(lines[3][0]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.invoke.php', 'punctuation.definition.arguments.end.bracket.round.php']
+      expect(lines[0][2]).toEqual value: '(', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.begin.bracket.round.php']
+      expect(lines[1][1]).toEqual value: 'bar', scopes: ['source.php', 'meta.function-call.php', 'entity.name.variable.parameter.php']
+      expect(lines[1][2]).toEqual value: ':', scopes: ['source.php', 'meta.function-call.php', 'punctuation.separator.colon.php']
+      expect(lines[2][1]).toEqual value: 'foo', scopes: ['source.php', 'meta.function-call.php', 'entity.name.variable.parameter.php']
+      expect(lines[2][2]).toEqual value: ':', scopes: ['source.php', 'meta.function-call.php', 'punctuation.separator.colon.php']
+      expect(lines[3][0]).toEqual value: ')', scopes: ['source.php', 'meta.function-call.php', 'punctuation.definition.arguments.end.bracket.round.php']
 
   describe 'method calls', ->
     it 'tokenizes method calls with no arguments', ->


### PR DESCRIPTION
PR #36 fixed #35, but it also introduced a theming/styling regression.

In
```php
$foo($bar);
```
both the callee (`$foo`) and the argument (`$bar`) ended up sharing the same effective scope stack,
`meta.function-call.invoke.php  variable.other.php`.
That makes it impossible for themes to target the callee separately from the arguments.

Regression example:

Before:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5a77f3cc-e91d-4415-8daa-7fde55be73cd" />


After:
<img width="250" alt="image" src="https://github.com/user-attachments/assets/cc48214c-5a0a-4dc2-a8bf-0810f4eb1f2c" />


This PR restores `meta.function-call.invoke.php` on the callee only, as it was before #36, while applying `meta.function-call.php` to the parenthesized argument list.
That preserves the named-argument fix from #35 and keeps invoke-call arguments aligned with the existing scoping model used for `foo($bar)`, `new foo($bar)`, and `new class($bar) {}`.
