### PR TITLE
fix: stop malformed regex syntax from leaking past PHP strings and REGEXP blocks

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2159,7 +2159,7 @@
             'captures':
               '0':
                 'name': 'punctuation.definition.character-class.php'
-            'end': '\\]|(?=$)'
+            'end': '\\]|(?=^\\s*(?:REGEXP?)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
             'name': 'string.regexp.character-class.php'
             'patterns': [
               {
@@ -2422,7 +2422,7 @@
             'captures':
               '0':
                 'name': 'punctuation.definition.character-class.php'
-            'end': '\\]|(?=$)'
+            'end': '\\]|(?=^\\s*(?:REGEXP?)(?![A-Za-z0-9_\\x{7f}-\\x{10ffff}]))'
             'name': 'string.regexp.character-class.php'
             'patterns': [
               {

--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -2159,7 +2159,7 @@
             'captures':
               '0':
                 'name': 'punctuation.definition.character-class.php'
-            'end': '\\]'
+            'end': '\\]|(?=$)'
             'name': 'string.regexp.character-class.php'
             'patterns': [
               {
@@ -2422,7 +2422,7 @@
             'captures':
               '0':
                 'name': 'punctuation.definition.character-class.php'
-            'end': '\\]'
+            'end': '\\]|(?=$)'
             'name': 'string.regexp.character-class.php'
             'patterns': [
               {
@@ -2968,7 +2968,7 @@
       '2':
         'name': 'keyword.other.array.phpdoc.php'
   'regex-double-quoted':
-    'begin': '"/(?=(\\\\.|[^"/])++/[imsxeADSUXu]*")'
+    'begin': '"/(?=(?:\\\\.|\\[(?:\\^?\\])?(?:\\\\.|[^\\]])*\\]|(?!["/\\\\\\[]).)++/[imsxeADSUXu]*")'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -3000,7 +3000,7 @@
         'captures':
           '0':
             'name': 'punctuation.definition.character-class.php'
-        'end': '\\]'
+        'end': '\\]|(?=/[imsxeADSUXu]*")|(?=$)'
         'name': 'string.regexp.character-class.php'
         'patterns': [
           {
@@ -3014,7 +3014,7 @@
       }
     ]
   'regex-single-quoted':
-    'begin': '\'/(?=(\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)|[^\'/])++/[imsxeADSUXu]*\')'
+    'begin': '\'/(?=(?:\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)|\\[(?:\\^?\\])?(?:\\\\(?:\\\\(?:\\\\[\\\\\']?|[^\'])|.)|[^\\]])*\\]|(?![\'/\\\\\\[]).)++/[imsxeADSUXu]*\')'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.php'
@@ -3041,7 +3041,7 @@
         'captures':
           '0':
             'name': 'punctuation.definition.character-class.php'
-        'end': '\\]'
+        'end': '\\]|(?=/[imsxeADSUXu]*\')|(?=$)'
         'name': 'string.regexp.character-class.php'
       }
       {

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4782,6 +4782,57 @@ describe 'PHP grammar', ->
         expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
         expectPlainAssignment(lines[3])
 
+  for {description, opener, label, regexScope, terminatorScope} in [
+    {
+      description: 'REGEX heredoc'
+      opener: '<<<REGEX'
+      label: 'REGEX'
+      regexScope: ['source.php', 'string.unquoted.heredoc.php', 'string.regexp.heredoc.php']
+      terminatorScope: ['source.php', 'string.unquoted.heredoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
+    }
+    {
+      description: 'REGEXP nowdoc'
+      opener: '<<<\'REGEXP\''
+      label: 'REGEXP'
+      regexScope: ['source.php', 'string.unquoted.nowdoc.php', 'string.regexp.nowdoc.php']
+      terminatorScope: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+    }
+  ]
+    do (description, opener, label, regexScope, terminatorScope) ->
+      it "should keep multiline character classes open in #{description}", ->
+        lines = grammar.tokenizeLines """
+          $r = #{opener}
+          /[ab
+          cd]/
+          #{label};
+          $x = 1;
+        """
+
+        expect(lines[1][0]).toEqual value: '/', scopes: regexScope
+        expect(lines[1][1]).toEqual value: '[', scopes: regexScope.concat ['string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+        expect(lines[1][2]).toEqual value: 'ab', scopes: regexScope.concat ['string.regexp.character-class.php']
+        expect(lines[2][0]).toEqual value: 'cd', scopes: regexScope.concat ['string.regexp.character-class.php']
+        expect(lines[2][1]).toEqual value: ']', scopes: regexScope.concat ['string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+        expect(lines[2][2]).toEqual value: '/', scopes: regexScope
+        expect(lines[3][0]).toEqual value: label, scopes: terminatorScope
+        expect(lines[3][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+        expectPlainAssignment(lines[4])
+
+      it "should stop multiline unclosed character classes at the terminator in #{description}", ->
+        lines = grammar.tokenizeLines """
+          $r = #{opener}
+          /[ab
+          #{label};
+          $x = 1;
+        """
+
+        expect(lines[1][0]).toEqual value: '/', scopes: regexScope
+        expect(lines[1][1]).toEqual value: '[', scopes: regexScope.concat ['string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+        expect(lines[1][2]).toEqual value: 'ab', scopes: regexScope.concat ['string.regexp.character-class.php']
+        expect(lines[2][0]).toEqual value: label, scopes: terminatorScope
+        expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+        expectPlainAssignment(lines[3])
+
   describe 'punctuation', ->
     it 'tokenizes brackets', ->
       {tokens} = grammar.tokenizeLine '{}'

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -8,6 +8,15 @@ describe 'PHP grammar', ->
     grammar = await loadGrammar('source.php')
   )
 
+  expectPlainAssignment = (tokens) ->
+    expect(tokens[0]).toEqual value: '$', scopes: ['source.php', 'variable.other.php', 'punctuation.definition.variable.php']
+    expect(tokens[1]).toEqual value: 'x', scopes: ['source.php', 'variable.other.php']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['source.php']
+    expect(tokens[3]).toEqual value: '=', scopes: ['source.php', 'keyword.operator.assignment.php']
+    expect(tokens[4]).toEqual value: ' ', scopes: ['source.php']
+    expect(tokens[5]).toEqual value: '1', scopes: ['source.php', 'constant.numeric.decimal.php']
+    expect(tokens[6]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe 'source.php'
@@ -3793,6 +3802,42 @@ describe 'PHP grammar', ->
     expect(tokens[1]).toEqual value: '\\[', scopes: ['source.php', 'string.regexp.single-quoted.php', 'constant.character.escape.php']
     expect(tokens[2]).toEqual value: '/\'', scopes: ['source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.end.php']
 
+  for {description, regex} in [
+    {description: 'empty character class', regex: '/[]/'}
+    {description: 'negated empty character class', regex: '/[^]/'}
+    {description: 'unclosed character class', regex: '/[a/'}
+    {description: 'unclosed negated character class', regex: '/[^a/'}
+    {description: 'slash after opening character class', regex: '/[/'}
+  ]
+    do (description, regex) ->
+      it "should not leak single quoted regex with #{description}", ->
+        lines = grammar.tokenizeLines "$r = '#{regex}';\n$x = 1;"
+
+        expectPlainAssignment(lines[1])
+
+      it "should not leak double quoted regex with #{description}", ->
+        lines = grammar.tokenizeLines "$r = \"#{regex}\";\n$x = 1;"
+
+        expectPlainAssignment(lines[1])
+
+  it 'should tokenize single quoted regex with slash inside character class', ->
+    {tokens} = grammar.tokenizeLine "'/[a/b]/'"
+
+    expect(tokens[0]).toEqual value: '\'/', scopes: ['source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.begin.php']
+    expect(tokens[1]).toEqual value: '[', scopes: ['source.php', 'string.regexp.single-quoted.php', 'string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+    expect(tokens[2]).toEqual value: 'a/b', scopes: ['source.php', 'string.regexp.single-quoted.php', 'string.regexp.character-class.php']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.php', 'string.regexp.single-quoted.php', 'string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+    expect(tokens[4]).toEqual value: '/\'', scopes: ['source.php', 'string.regexp.single-quoted.php', 'punctuation.definition.string.end.php']
+
+  it 'should tokenize double quoted regex with slash inside character class', ->
+    {tokens} = grammar.tokenizeLine "\"/[a/b]/\""
+
+    expect(tokens[0]).toEqual value: '"/', scopes: ['source.php', 'string.regexp.double-quoted.php', 'punctuation.definition.string.begin.php']
+    expect(tokens[1]).toEqual value: '[', scopes: ['source.php', 'string.regexp.double-quoted.php', 'string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+    expect(tokens[2]).toEqual value: 'a/b', scopes: ['source.php', 'string.regexp.double-quoted.php', 'string.regexp.character-class.php']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.php', 'string.regexp.double-quoted.php', 'string.regexp.character-class.php', 'punctuation.definition.character-class.php']
+    expect(tokens[4]).toEqual value: '/"', scopes: ['source.php', 'string.regexp.double-quoted.php', 'punctuation.definition.string.end.php']
+
   it 'should tokenize opening scope of a closure correctly', ->
     {tokens} = grammar.tokenizeLine '$a = function() {};'
 
@@ -4704,6 +4749,38 @@ describe 'PHP grammar', ->
     expect(lines[1][2]).toEqual value: '/', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'string.regexp.nowdoc.php']
     expect(lines[2][0]).toEqual value: 'REGEXP', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+
+  for {description, regex} in [
+    {description: 'empty character class', regex: '/[]/'}
+    {description: 'negated empty character class', regex: '/[^]/'}
+    {description: 'unclosed character class', regex: '/[a/'}
+    {description: 'unclosed negated character class', regex: '/[^a/'}
+    {description: 'slash after opening character class', regex: '/[/'}
+  ]
+    do (description, regex) ->
+      it "should not leak REGEXP heredoc with #{description}", ->
+        lines = grammar.tokenizeLines """
+          $r = <<<REGEXP
+          #{regex}
+          REGEXP;
+          $x = 1;
+        """
+
+        expect(lines[2][0]).toEqual value: 'REGEXP', scopes: ['source.php', 'string.unquoted.heredoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.heredoc.php']
+        expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+        expectPlainAssignment(lines[3])
+
+      it "should not leak REGEXP nowdoc with #{description}", ->
+        lines = grammar.tokenizeLines """
+          $r = <<<'REGEXP'
+          #{regex}
+          REGEXP;
+          $x = 1;
+        """
+
+        expect(lines[2][0]).toEqual value: 'REGEXP', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+        expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
+        expectPlainAssignment(lines[3])
 
   describe 'punctuation', ->
     it 'tokenizes brackets', ->


### PR DESCRIPTION
Closes #38 and fixes several related cases where malformed regex syntax leaked highlighting into later code in single-quoted strings, double-quoted strings, and explicit `REGEX`/`REGEXP` heredoc/nowdoc blocks.
It also adds support for valid quoted regexes that were previously missed when `/` appeared inside a character class, such as `'/[a/b]/'`.

The fix makes quoted regex detection character-class-aware so unterminated classes do not get recognized as complete regexes in the first place. For explicit `REGEX`/`REGEXP` blocks, nested character classes now use the block terminator as an emergency exit, which prevents file-wide leaks while still allowing multiline character classes to remain open across lines until they close normally.

Before:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/61abaaf1-e263-4511-984e-683f10a530e6" />


After:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0052078d-492a-4fdb-9207-9d143ba8bcc9" />
