### PR TITLE
Fix Unicode nowdoc labels

### DIFF
--- a/grammars/php.cson
+++ b/grammars/php.cson
@@ -1938,7 +1938,7 @@
         ]
       }
       {
-        'begin': '(?=<<<\\s*\'([a-zA-Z_]+[a-zA-Z0-9_]*)\'\\s*$)'
+        'begin': '(?i)(?=<<<\\s*\'([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\'\\s*$)'
         'end': '(?!\\G)'
         'name': 'string.unquoted.nowdoc.php'
         'patterns': [

--- a/spec/php-spec.coffee
+++ b/spec/php-spec.coffee
@@ -4250,6 +4250,21 @@ describe 'PHP grammar', ->
     expect(lines[2][0]).toEqual value: 'SQL', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'meta.embedded.sql', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
     expect(lines[2][1]).toEqual value: ';', scopes: ['source.php', 'punctuation.terminator.expression.php']
 
+  it 'should tokenize a nowdoc with a unicode label correctly', ->
+    lines = grammar.tokenizeLines '''
+      $a = <<<'NOW📄'
+      body
+      NOW📄;
+      function seeme() {}
+    '''
+
+    expect(lines[0][5]).toEqual value: '<<<', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.begin.php', 'punctuation.definition.string.php']
+    expect(lines[0][7]).toEqual value: 'NOW📄', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.begin.php', 'keyword.operator.nowdoc.php']
+    expect(lines[1][0]).toEqual value: 'body', scopes: ['source.php', 'string.unquoted.nowdoc.php']
+    expect(lines[2][0]).toEqual value: 'NOW📄', scopes: ['source.php', 'string.unquoted.nowdoc.php', 'punctuation.section.embedded.end.php', 'keyword.operator.nowdoc.php']
+    expect(lines[3][0]).toEqual value: 'function', scopes: ['source.php', 'meta.function.php', 'storage.type.function.php']
+    expect(lines[3][2]).toEqual value: 'seeme', scopes: ['source.php', 'meta.function.php', 'entity.name.function.php']
+
   it 'should tokenize a heredoc with embedded DQL correctly', ->
     lines = grammar.tokenizeLines '''
       $a = <<<DQL


### PR DESCRIPTION
### Description of the Change

Nowdoc labels currently only accept ASCII identifiers in the outer nowdoc lookahead, while heredoc labels already accept PHP's extended identifier range. This means a nowdoc such as `<<<'NOW📄'` is not recognized as a nowdoc string and the rest of the file can be tokenized with the wrong scopes.

This updates the nowdoc label lookahead to use the same Unicode identifier range as heredoc labels, and adds a regression spec for a Unicode nowdoc label followed by normal PHP code.

### Alternate Designs

I kept the change limited to the nowdoc opener. The existing nowdoc terminator patterns already use the captured label and guard against Unicode identifier continuations.

### Possible Drawbacks

This broadens nowdoc labels to the same range already accepted for heredoc labels. I don't expect this to affect ASCII nowdoc labels.

### Applicable Issues

Related to microsoft/vscode#322943 and microsoft/vscode#323831.

### Verification

- Added a CoffeeScript grammar spec for `<<<'NOW📄'`.
- Ran a direct `vscode-oniguruma` check against the old and new nowdoc label patterns: the old pattern rejects `NOW📄`, the new pattern accepts it while still rejecting a label starting with a digit.
- Ran `git diff --check`.

I could not run the full `npm test` suite locally because both `yarn install --frozen-lockfile` and `npm install --no-package-lock` failed with registry `503 Service Unavailable` errors while fetching dependencies.
